### PR TITLE
Update kotlin version from 1.3 to 1.4 including libraries

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 plugins {
-    kotlin("jvm") version "1.3.72" apply false
+    kotlin("jvm") version "1.4.10" apply false
 }
 
 allprojects {

--- a/client-runtime/build.gradle.kts
+++ b/client-runtime/build.gradle.kts
@@ -37,6 +37,10 @@ fun projectNeedsPlatform(project: Project, platform: String ): Boolean {
     return files.any{ it.name == platform || (it.name == "common" && platform == "jvm")}
 }
 
+kotlin {
+    jvm() // Create a JVM target with the default name 'jvm'
+}
+
 subprojects {
     group = "software.aws.kotlin"
     version = "0.0.1"

--- a/client-runtime/protocols/build.gradle.kts
+++ b/client-runtime/protocols/build.gradle.kts
@@ -1,0 +1,3 @@
+kotlin {
+    jvm() // Create a JVM target with the default name 'jvm'
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,11 +5,11 @@ smithyVersion=1.0.11
 smithyKotlinVersion=0.1.0
 
 # kotlin
-kotlinVersion=1.3.72
+kotlinVersion=1.4.10
 kotlin.native.ignoreDisabledTargets=true
 
 # kotlin libraries
-coroutinesVersion=1.3.7
+coroutinesVersion=1.3.9
 
 # default smithy-kotlin:client-runtime library version
 smithyKotlinClientRtVersion=0.0.1

--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -7,7 +7,7 @@ kotlin.sourceSets {
     commonMain.dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-common"
         implementation group: "org.jetbrains.kotlin", name: "kotlin-stdlib-common", version: kotlinVersion
-        implementation group: "org.jetbrains.kotlinx", name: "kotlinx-coroutines-core-common", version: coroutinesVersion
+        implementation group: "org.jetbrains.kotlinx", name: "kotlinx-coroutines-core", version: coroutinesVersion
     }
     commonTest.dependencies {
         implementation "org.jetbrains.kotlin:kotlin-test-common:$kotlinVersion"


### PR DESCRIPTION
Issue #: /story/show/174863447

Accompanying PR: https://github.com/awslabs/smithy-kotlin/pull/5

This PR updates Kotlin dependencies based on the latest recommended versions from this page: https://kotlinlang.org/releases.html#release-details.

## Testing Done
* aws-sdk-kotlin build and unit tests pass
* Generated protocol test suite compiles and all tests pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
