### PR TITLE
composite build extension

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,19 +35,43 @@ include(":client-runtime:auth")
 include(":client-runtime:protocols:http")
 include(":client-runtime:protocols:rest-json")
 
+/**
+ * The following code enables to optionally include aws-sdk-kotlin dependencies in source form for easier
+ * development.  By default, if `smithy-kotlin` exists as a directory at the same level as `aws-sdk-kotlin`
+ * then `smithy-kotlin` will be added as a composite build.  To override this behavior, for example to add
+ * more composite builds, specify a different directory for `smithy-kotlin`, or to disable the feature entirely,
+ * a local.properties file can be added or amended such that the property `compositeProjects` specifies
+ * a comma delimited list of paths to project roots that shall be added as composite builds.  If the list is
+ * empty to builds will be added.  Invalid directories are ignored.  Example local.properties:
+ *
+ * compositeProjects=~/repos/smithy-kotlin,/tmp/some/other/thing,../../another/project
+ *
+ */
 val compositeProjectList = try {
     val localProperties = java.util.Properties()
     localProperties.load(File(rootProject.projectDir, "local.properties").inputStream())
-    localProperties.getProperty("compositeProjects")
-        ?.splitToSequence(",")
-        ?.map { file(it) }
+    val filePaths = localProperties.getProperty("compositeProjects")
+        ?.splitToSequence(",")  // Split comma delimited string into sequence
+        ?.map { it.replaceFirst("^~".toRegex(), System.getProperty("user.home")) } // expand user dir
+        ?.map { file(it) } // Create file from path
         ?.toList()
         ?: emptyList()
+
+    if (filePaths.isNotEmpty()) println("Adding ${filePaths.size} composite build directories from local.properties.")
+    filePaths
+} catch (e: java.io.FileNotFoundException) {
+    listOf(file("../smithy-kotlin")) // Default path, not an error.
 } catch (e: Throwable) {
+    logger.error("Failed to load project paths from local.properties. Assuming defaults.", e)
     listOf(file("../smithy-kotlin"))
 }
 
-compositeProjectList.filter { it.exists() }.forEach {
-    println("Including build '$it'")
-    includeBuild(it)
+compositeProjectList.forEach { projectRoot ->
+    when (projectRoot.exists()) {
+        true -> {
+            println("Including build '$projectRoot'")
+            includeBuild(projectRoot)
+        }
+        false -> println("Ignoring invalid build directory '$projectRoot'.")
+    }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This adds the composite build feature that Aaron found and tested out to `aws-sdk-kotlin` to allow `smithy-kotlin` plus anything else specified in `local.properties` to be loaded as a composite build.

## Testing Done
* Verify that the default `smithy-kotlin` is loaded if exists and no local properties found
* Verify that custom paths from local.properties are loaded 
* Verify that non-existent file paths cause no change to build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
