### PR TITLE
Fix to allow specifying no composite build modules 

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -59,6 +59,7 @@ val compositeProjectList = try {
     val filePaths = localProperties.getProperty("compositeProjects")
         ?.splitToSequence(",")  // Split comma delimited string into sequence
         ?.map { it.replaceFirst("^~".toRegex(), System.getProperty("user.home")) } // expand user dir
+        ?.filter { it.isNotBlank() }
         ?.map { file(it) } // Create file from path
         ?.toList()
         ?: emptyList()


### PR DESCRIPTION
by setting the property to empty string.

*Issue #, if available:* N/A

# Description of changes:
* If the property value is set like `compositeProjects=` then the existing code tries to create an instance of Java File with empty string which breaks the build.  This filters that case out so users can specify no composite builds by setting the property to empty.

# Testing done

* Run w/ fix, observe that composite builds are not included in project.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
