### PR TITLE
Implement writing of sdkId to smithy-build.json.

### DIFF
--- a/codegen/smithy-aws-kotlin-codegen/src/test/kotlin/TestUtils.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/test/kotlin/TestUtils.kt
@@ -42,7 +42,7 @@ fun Model.generateTestContext(namespace: String, serviceName: String): ProtocolG
             .withMember("moduleVersion", Node.from("1.0.0"))
             .build()
     )
-    val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(this, namespace)
+    val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(this, namespace, serviceName)
     val service = this.expectShape<ServiceShape>("$namespace#$serviceName")
     val generator: ProtocolGenerator = MockHttpProtocolGenerator()
     val manifest = MockManifest()


### PR DESCRIPTION
*Issue #, if available:* /story/show/175850640

Companion PR: https://github.com/awslabs/smithy-kotlin/pull/43

*Description of changes:*
* Add a field `sdkId` to the `smithy-build.json` file in the sdk-codegen module.  Allows geneartion of SDK client name based on [smithy spec](https://awslabs.github.io/smithy/1.0/spec/aws/aws-core.html#using-sdk-service-id-for-client-naming).
* Refactor build script, misc cleanup

## Testing done

* unit tests pass
* api gateway, lambda services tested.  Can call services with some simple hand written test code.
* protocol test suites pass for 3 protocols.  There are 6 service errors but unrelated to client name generation.
* in intermediary form, produced `smithy-build.json` files copies both in old and new codebase, did manual diff to verify correctness


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
