### PR TITLE
Manually specify build order to avoid deadlock during build.

### DIFF
--- a/client-runtime/auth/build.gradle.kts
+++ b/client-runtime/auth/build.gradle.kts
@@ -27,7 +27,3 @@ kotlin {
         }
     }
 }
-
-// Resolves build deadlock with aws-client-rt
-tasks["generatePomFileForJvmPublication"]
-    .dependsOn(":client-runtime:aws-client-rt:generatePomFileForJvmPublication")

--- a/client-runtime/build.gradle.kts
+++ b/client-runtime/build.gradle.kts
@@ -86,6 +86,11 @@ subprojects {
     apply(from = rootProject.file("gradle/publish.gradle"))
 }
 
+// resolves build deadlock with aws-client-rt when using composite builds
+subprojects.filter { it.name != "aws-client-rt" }.forEach { proj ->
+    proj.tasks.findByName("generatePomFileForJvmPublication")?.dependsOn(":client-runtime:aws-client-rt:generatePomFileForJvmPublication")
+}
+
 task<org.jetbrains.kotlin.gradle.testing.internal.KotlinTestReport>("rootAllTest"){
     destinationDir = File(project.buildDir, "reports/tests/rootAllTest")
     val rootAllTest = this

--- a/client-runtime/crt-util/build.gradle.kts
+++ b/client-runtime/crt-util/build.gradle.kts
@@ -22,6 +22,3 @@ kotlin {
     }
 }
 
-// Resolves build deadlock with aws-client-rt
-tasks["generatePomFileForJvmPublication"]
-    .dependsOn(":client-runtime:aws-client-rt:generatePomFileForJvmPublication")

--- a/client-runtime/protocols/http/build.gradle.kts
+++ b/client-runtime/protocols/http/build.gradle.kts
@@ -27,6 +27,3 @@ kotlin {
     }
 }
 
-// Resolves build deadlock with aws-client-rt
-tasks["generatePomFileForJvmPublication"]
-    .dependsOn(":client-runtime:aws-client-rt:generatePomFileForJvmPublication")

--- a/client-runtime/protocols/rest-json/build.gradle.kts
+++ b/client-runtime/protocols/rest-json/build.gradle.kts
@@ -30,6 +30,3 @@ kotlin {
     }
 }
 
-// Resolves build deadlock with aws-client-rt
-tasks["generatePomFileForJvmPublication"]
-    .dependsOn(":client-runtime:aws-client-rt:generatePomFileForJvmPublication")

--- a/client-runtime/regions/build.gradle.kts
+++ b/client-runtime/regions/build.gradle.kts
@@ -22,6 +22,3 @@ kotlin {
     }
 }
 
-// Resolves build deadlock with aws-client-rt
-tasks["generatePomFileForJvmPublication"]
-    .dependsOn(":client-runtime:aws-client-rt:generatePomFileForJvmPublication")


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This change causes client-runtime modules to first build the common root dependency `aws-client-rt` for the gradle task `generatePomFileForJvmPublication`.

It's unclear to me why this build dependency must be explicit, but resolves the issue nonetheless.

## Testing done
* before change, following commandline command results in a deadlock: `cd client-runtime && ../gradlew --debug clean publishToMavenLocal`
* after change the above build command completes successfully

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
