### PR TITLE
Rename client runtime packages to aws.sdk.kotlin.runtime 2

### DIFF
--- a/client-runtime/auth/build.gradle.kts
+++ b/client-runtime/auth/build.gradle.kts
@@ -5,7 +5,7 @@
 
 description = "AWS Service Authentication"
 extra["displayName"] = "Software :: AWS :: Kotlin SDK :: Auth"
-extra["moduleName"] = "software.aws.kotlinsdk.auth"
+extra["moduleName"] = "aws.sdk.kotlin.runtime.auth"
 
 val smithyKotlinClientRtVersion: String by project
 

--- a/client-runtime/aws-client-rt/build.gradle.kts
+++ b/client-runtime/aws-client-rt/build.gradle.kts
@@ -5,7 +5,7 @@
 
 description = "AWS client runtime support for generated service clients"
 extra["displayName"] = "Software :: AWS :: Kotlin SDK :: Client Runtime"
-extra["moduleName"] = "software.aws.kotlinsdk"
+extra["moduleName"] = "aws.sdk.kotlin.runtime"
 
 
 val smithyKotlinClientRtVersion: String by project

--- a/client-runtime/build.gradle.kts
+++ b/client-runtime/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
 }
 
 subprojects {
-    group = "software.aws.kotlin"
+    group = "aws.sdk.kotlin.runtime"
     version = "0.0.1"
 
     apply {

--- a/client-runtime/crt-util/build.gradle.kts
+++ b/client-runtime/crt-util/build.gradle.kts
@@ -5,7 +5,7 @@
 
 description = "Utilities for working with AWS CRT Kotlin"
 extra["displayName"] = "Software :: AWS :: Kotlin SDK :: CRT :: Util"
-extra["moduleName"] = "software.aws.kotlinsdk.crt"
+extra["moduleName"] = "aws.sdk.kotlin.runtime.crt"
 
 val smithyKotlinClientRtVersion: String by project
 val crtKotlinVersion: String by project

--- a/client-runtime/protocols/http/build.gradle.kts
+++ b/client-runtime/protocols/http/build.gradle.kts
@@ -5,7 +5,7 @@
 
 description = "HTTP core for AWS service clients"
 extra["displayName"] = "Software :: AWS :: Kotlin SDK :: HTTP"
-extra["moduleName"] = "software.aws.kotlinsdk.http"
+extra["moduleName"] = "aws.sdk.kotlin.runtime.http"
 
 val smithyKotlinClientRtVersion: String by project
 

--- a/client-runtime/protocols/rest-json/build.gradle.kts
+++ b/client-runtime/protocols/rest-json/build.gradle.kts
@@ -5,7 +5,7 @@
 
 description = "JSON protocol support for AWS service clients"
 extra["displayName"] = "Software :: AWS :: Kotlin SDK :: RestJSON"
-extra["moduleName"] = "software.aws.kotlinsdk.restjson"
+extra["moduleName"] = "aws.sdk.kotlin.runtime.restjson"
 
 val smithyKotlinClientRtVersion: String by project
 

--- a/client-runtime/regions/build.gradle.kts
+++ b/client-runtime/regions/build.gradle.kts
@@ -5,7 +5,7 @@
 
 description = "AWS Region Support"
 extra["displayName"] = "Software :: AWS :: Kotlin SDK :: Regions"
-extra["moduleName"] = "software.aws.kotlinsdk.regions"
+extra["moduleName"] = "aws.sdk.kotlin.runtime.regions"
 
 kotlin {
     sourceSets {

--- a/codegen/protocol-test-codegen/smithy-build.json
+++ b/codegen/protocol-test-codegen/smithy-build.json
@@ -13,7 +13,7 @@
       "plugins": {
         "kotlin-codegen": {
           "service": "aws.protocoltests.restjson#RestJson",
-          "module": "software.aws.kotlinsdk.protocoltest.awsrestjson",
+          "module": "aws.sdk.kotlin.runtime.protocoltest.awsrestjson",
           "moduleVersion": "1.0",
           "build":  {
               "rootProject": true
@@ -33,7 +33,7 @@
       "plugins": {
         "kotlin-codegen": {
           "service": "aws.protocoltests.json10#JsonRpc10",
-          "module": "software.aws.kotlinsdk.protocoltest.awsjson10",
+          "module": "aws.sdk.kotlin.runtime.protocoltest.awsjson10",
           "moduleVersion": "1.0",
           "build":  {
             "rootProject": true
@@ -53,7 +53,7 @@
       "plugins": {
         "kotlin-codegen": {
           "service": "aws.protocoltests.json#JsonProtocol",
-          "module": "software.aws.kotlinsdk.protocoltest.awsjson11",
+          "module": "aws.sdk.kotlin.runtime.protocoltest.awsjson11",
           "moduleVersion": "1.0",
           "build":  {
             "rootProject": true

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/AwsKotlinDependency.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/AwsKotlinDependency.kt
@@ -8,12 +8,12 @@ import software.amazon.smithy.kotlin.codegen.GradleConfiguration
 import software.amazon.smithy.kotlin.codegen.KotlinDependency
 
 // root namespace for the AWS client-runtime
-const val AWS_CLIENT_RT_ROOT_NS = "software.aws.kotlinsdk"
-const val AWS_CLIENT_RT_AUTH_NS = "software.aws.kotlinsdk.auth"
-const val AWS_CLIENT_RT_REGIONS_NS = "software.aws.kotlinsdk.regions"
+const val AWS_CLIENT_RT_ROOT_NS = "aws.sdk.kotlin.runtime"
+const val AWS_CLIENT_RT_AUTH_NS = "aws.sdk.kotlin.runtime.auth"
+const val AWS_CLIENT_RT_REGIONS_NS = "aws.sdk.kotlin.runtime.regions"
 
 // publishing info
-const val AWS_CLIENT_RT_GROUP = "software.aws.kotlin"
+const val AWS_CLIENT_RT_GROUP = "aws.sdk.kotlin.runtime"
 const val AWS_CLIENT_RT_VERSION = "0.0.1"
 
 /**

--- a/design/s3-example/build.gradle.kts
+++ b/design/s3-example/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 val smithyKotlinClientRtVersion: String by project
 val smithyKotlinGroup: String = "software.aws.smithy.kotlin"
 
-val experimentalAnnotations = listOf("kotlin.RequiresOptIn", "software.aws.clientrt.util.InternalAPI", "software.aws.kotlinsdk.InternalSdkApi")
+val experimentalAnnotations = listOf("kotlin.RequiresOptIn", "software.aws.clientrt.util.InternalAPI", "aws.sdk.kotlin.runtime.InternalSdkApi")
 kotlin {
     sourceSets {
         all {


### PR DESCRIPTION
Fix missed references to package namespaces renamed in https://githu.com/awslabs/aws-sdk-kotlin/pull/54.

*Issue #, if available:* /story/show/176265266

## Description of changes:
This PR updates some missed package names still referencing `software.aws.kotlinsdk` as the sdk runtime namespace that were missed in https://github.com/awslabs/aws-sdk-kotlin/pull/54.

## Testing done
1. Deleted stale binary local dependencies to `software.aws.kotlin*` in my local maven repository
2. Verified compilation failure locally as a result
3. Updated code to diff seen here, cleaned and published locally
4. Verified unit tests pass
5. Verified Protocol codegen tests pass
6. Verified Lambda SDK generates, produces gradle file with updated group names, and compiles successfully



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
