### PR TITLE
fix: escape windows paths in emitted json smithy-build.json

### DIFF
--- a/codegen/sdk/build.gradle.kts
+++ b/codegen/sdk/build.gradle.kts
@@ -70,9 +70,11 @@ data class AwsService(
 fun generateSmithyBuild(services: List<AwsService>): String {
 
     val projections = services.joinToString(",") { service ->
+        // escape windows paths for valid json
+        val absModelPath = service.modelFile.absolutePath.replace("\\", "\\\\")
         """
             "${service.projectionName}": {
-                "imports": ["${service.modelFile.absolutePath}"],
+                "imports": ["$absModelPath"],
                 "plugins": {
                     "kotlin-codegen": {
                       "service": "${service.name}",


### PR DESCRIPTION
*Issue #, if available:*
#58 

*Description of changes:*
Escape Windows file paths in the JSON emitted for `smithy-build.json`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
