### PR TITLE
fix: don't build any of the HTTP builders mid-flight since they can o…

### DIFF
--- a/client-runtime/crt-util/common/src/aws/sdk/kotlin/crt/Http.kt
+++ b/client-runtime/crt-util/common/src/aws/sdk/kotlin/crt/Http.kt
@@ -33,7 +33,7 @@ public fun HttpRequestBuilder.toSignableCrtRequest(): HttpRequestCrt {
     // HttpBody.Streaming are not signable without consuming the stream.
     // We will have to reconcile this with event-streams which have signed chunks...
     val bodyStream = (body as? HttpBody.Bytes)?.let { HttpRequestBodyStream.fromByteArray(it.bytes()) }
-    return HttpRequestCrt(method.name, url.build().encodedPath(), HttpHeadersCrt(headers), bodyStream)
+    return HttpRequestCrt(method.name, url.encodedPath, HttpHeadersCrt(headers), bodyStream)
 }
 
 // proxy the smithy-client-rt version of Headers to CRT (which is based on our client-rt version in the first place)


### PR DESCRIPTION
Pivotal: [176929501](/story/show/176929501)
smithy-kotlin: https://github.com/awslabs/smithy-kotlin/pull/54

*Description of changes:*
[QueryParameters](https://github.com/awslabs/smithy-kotlin/blob/main/client-runtime/protocol/http/common/src/software/aws/clientrt/http/QueryParameters.kt#L24) and [Headers](https://github.com/awslabs/smithy-kotlin/blob/main/client-runtime/protocol/http/common/src/software/aws/clientrt/http/Headers.kt#L26) builder's can only be "built" once (at least in their current state).

We had some code paths that were building these objects for requests in-flight, they are only meant to be built when ready to convert them to an immutable version (at which point the builders should no longer be used).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
