### PR TITLE
awsJson HTTP header deserialization fix

### DIFF
--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/awsjson/AwsJsonHttpBindingResolver.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/awsjson/AwsJsonHttpBindingResolver.kt
@@ -52,7 +52,7 @@ class AwsJsonHttpBindingResolver(
 
         val inputs = generationContext.model.expectShape(operationShape.input.get())
 
-        return inputs.members().map { member -> HttpBindingDescriptor(member, HttpBinding.Location.DOCUMENT, "") }.toList()
+        return inputs.members().map { member -> HttpBindingDescriptor(member, HttpBinding.Location.DOCUMENT) }.toList()
     }
 
     /**
@@ -65,7 +65,7 @@ class AwsJsonHttpBindingResolver(
 
                 val outputs = generationContext.model.expectShape(shape.output.get())
 
-                outputs.members().map { member -> HttpBindingDescriptor(member, HttpBinding.Location.DOCUMENT, "") }.toList()
+                outputs.members().map { member -> HttpBindingDescriptor(member, HttpBinding.Location.DOCUMENT) }.toList()
             }
             is StructureShape -> shape.members().map { member -> member.toHttpBindingDescriptor() }.toList()
             else -> {

--- a/codegen/smithy-aws-kotlin-codegen/src/test/kotlin/aws/sdk/kotlin/codegen/awsjson/AwsJsonHttpBindingResolverTest.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/test/kotlin/aws/sdk/kotlin/codegen/awsjson/AwsJsonHttpBindingResolverTest.kt
@@ -80,7 +80,7 @@ class AwsJsonHttpBindingResolverTest {
         Assertions.assertEquals(binding.member.id.toString(), "smithy.example#GetFooInput\$bigInt")
         Assertions.assertEquals(binding.location, HttpBinding.Location.DOCUMENT)
         // Location name is unused by awsJson
-        Assertions.assertEquals(binding.locationName, "")
+        Assertions.assertEquals(binding.locationName, null)
     }
 
     @Test
@@ -108,7 +108,7 @@ class AwsJsonHttpBindingResolverTest {
         Assertions.assertEquals(binding.member.id.toString(), "smithy.example#GetFooOutput\$bigInt")
         Assertions.assertEquals(binding.location, HttpBinding.Location.DOCUMENT)
         // Location name is unused by awsJson
-        Assertions.assertEquals(binding.locationName, "")
+        Assertions.assertEquals(binding.locationName, null)
     }
 
     @Test
@@ -136,6 +136,6 @@ class AwsJsonHttpBindingResolverTest {
         Assertions.assertEquals(binding.member.id.toString(), "smithy.example#GetFooOutput\$bigInt")
         Assertions.assertEquals(binding.location, HttpBinding.Location.DOCUMENT)
         // Location name is unused by awsJson
-        Assertions.assertEquals(binding.locationName, "")
+        Assertions.assertEquals(binding.locationName, null)
     }
 }


### PR DESCRIPTION
Fix HTTP header deserialization by specifying correct HttpBinding.Location based on traits associated w/ shape.

*Issue #, if available:* /story/show/176989755

Companion PR: https://github.com/awslabs/smithy-kotlin/pull/63

*Description of changes:*
* Specify HttpBindingLocation based on traits on Shape, rather than assuming DOCUMENT for everything

## Testing Done

* Verified that transfer and migrationhub both compile and deserailizers look ok after change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
