### PR TITLE
refactor(codegen): change CodeWriter expression start character

### DIFF
--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/AwsHttpProtocolClientGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/AwsHttpProtocolClientGenerator.kt
@@ -26,8 +26,8 @@ class AwsHttpProtocolClientGenerator(
 
     override fun render(writer: KotlinWriter) {
         writer.write("\n\n")
-        writer.write("const val ServiceId: String = \$S", ctx.service.sdkId)
-        writer.write("const val ServiceApiVersion: String = \$S", ctx.service.version)
+        writer.write("const val ServiceId: String = #S", ctx.service.sdkId)
+        writer.write("const val ServiceApiVersion: String = #S", ctx.service.version)
         writer.write("\n\n")
         super.render(writer)
 

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/AwsSignatureVersion4.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/AwsSignatureVersion4.kt
@@ -34,7 +34,7 @@ class AwsSignatureVersion4(private val signingServiceName: String) : HttpFeature
 
     override fun renderConfigure(writer: KotlinWriter) {
         writer.write("credentialsProvider = config.credentialsProvider ?: DefaultChainCredentialsProvider()")
-        writer.write("signingService = \$S", signingServiceName)
+        writer.write("signingService = #S", signingServiceName)
     }
 
     companion object {

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/EndpointResolverGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/EndpointResolverGenerator.kt
@@ -40,7 +40,7 @@ class EndpointResolverGenerator(private val endpointData: ObjectNode) {
 
         writer.openBlock("internal class DefaultEndpointResolver : EndpointResolver {", "}") {
             writer.openBlock("override suspend fun resolve(service: String, region: String): Endpoint {", "}") {
-                writer.write("return resolveEndpoint(servicePartitions, region) ?: throw ClientException(\$S)", "unable to resolve endpoint for region: \$region")
+                writer.write("return resolveEndpoint(servicePartitions, region) ?: throw ClientException(#S)", "unable to resolve endpoint for region: \$region")
             }
         }
     }
@@ -72,10 +72,10 @@ class EndpointResolverGenerator(private val endpointData: ObjectNode) {
 
     private fun renderPartition(writer: KotlinWriter, partitionNode: PartitionNode) {
         writer.openBlock("Partition(", "),") {
-            writer.write("id = \$S,", partitionNode.id)
-                .write("regionRegex = Regex(\$S),", partitionNode.config.expectStringMember("regionRegex").value)
-                .write("partitionEndpoint = \$S,", partitionNode.partitionEndpoint ?: "")
-                .write("isRegionalized = \$L,", partitionNode.partitionEndpoint == null)
+            writer.write("id = #S,", partitionNode.id)
+                .write("regionRegex = Regex(#S),", partitionNode.config.expectStringMember("regionRegex").value)
+                .write("partitionEndpoint = #S,", partitionNode.partitionEndpoint ?: "")
+                .write("isRegionalized = #L,", partitionNode.partitionEndpoint == null)
                 .openBlock("defaults = EndpointDefinition(", "),") {
                     renderEndpointDefinition(writer, partitionNode.defaults)
                 }
@@ -83,9 +83,9 @@ class EndpointResolverGenerator(private val endpointData: ObjectNode) {
                     partitionNode.endpoints.members.forEach {
                         val definitionNode = it.value.expectObjectNode()
                         if (definitionNode.members.isEmpty()) {
-                            writer.write("\$S to EndpointDefinition(),", it.key.value)
+                            writer.write("#S to EndpointDefinition(),", it.key.value)
                         } else {
-                            writer.openBlock("\$S to EndpointDefinition(", "),", it.key.value) {
+                            writer.openBlock("#S to EndpointDefinition(", "),", it.key.value) {
                                 renderEndpointDefinition(writer, it.value.expectObjectNode())
                             }
                         }
@@ -96,29 +96,29 @@ class EndpointResolverGenerator(private val endpointData: ObjectNode) {
 
     private fun renderEndpointDefinition(writer: KotlinWriter, endpointNode: ObjectNode) {
         endpointNode.getStringMember("hostname").ifPresent {
-            writer.write("hostname = \$S,", it)
+            writer.write("hostname = #S,", it)
         }
 
         endpointNode.getArrayMember("protocols").ifPresent {
             writer.writeInline("protocols = listOf(")
-            it.forEach { writer.writeInline("\$S, ", it.expectStringNode().value) }
+            it.forEach { writer.writeInline("#S, ", it.expectStringNode().value) }
             writer.write("),")
         }
 
         endpointNode.getObjectMember("credentialScope").ifPresent {
             writer.writeInline("credentialScope = CredentialScope(")
             it.getStringMember("region").ifPresent {
-                writer.writeInline("region = \$S,", it.value)
+                writer.writeInline("region = #S,", it.value)
             }
             it.getStringMember("service").ifPresent {
-                writer.writeInline("service= \$S", it.value)
+                writer.writeInline("service= #S", it.value)
             }
             writer.write("),")
         }
 
         endpointNode.getArrayMember("signatureVersions").ifPresent {
             writer.writeInline("signatureVersions = listOf(")
-            it.forEach { writer.writeInline("\$S, ", it.expectStringNode().value) }
+            it.forEach { writer.writeInline("#S, ", it.expectStringNode().value) }
             writer.write("),")
         }
     }

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/GradleGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/GradleGenerator.kt
@@ -34,11 +34,12 @@ class GradleGenerator : KotlinIntegration {
             trimBlankLines()
             trimTrailingSpaces()
             setIndentText("    ")
+            expressionStart = '#'
         }
 
         writer.write("")
         if (ctx.settings.moduleDescription.isNotEmpty()) {
-            writer.write("description = \$S", ctx.settings.moduleDescription)
+            writer.write("description = #S", ctx.settings.moduleDescription)
         }
 
         val dependencies = delegator.dependencies.mapNotNull { it.properties["dependency"] as? KotlinDependency }.distinct()

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/awsjson/AwsJson1_0.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/awsjson/AwsJson1_0.kt
@@ -63,6 +63,6 @@ class AwsJsonTargetHeaderFeature(val protocolVersion: String) : HttpFeature {
     }
 
     override fun renderConfigure(writer: KotlinWriter) {
-        writer.write("version = \$S", protocolVersion)
+        writer.write("version = #S", protocolVersion)
     }
 }

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/awsjson/AwsJsonModeledExceptionsFeature.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/awsjson/AwsJsonModeledExceptionsFeature.kt
@@ -19,7 +19,7 @@ class AwsJsonModeledExceptionsFeature(
             val symbol = ctx.symbolProvider.toSymbol(errShape)
             val deserializerName = "${symbol.name}Deserializer"
 
-            writer.write("register(code = \$S, deserializer = $deserializerName())", code)
+            writer.write("register(code = #S, deserializer = $deserializerName())", code)
         }
     }
 }

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/protocoltest/AwsHttpProtocolUnitTestRequestGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/protocoltest/AwsHttpProtocolUnitTestRequestGenerator.kt
@@ -52,7 +52,7 @@ internal fun <T : HttpMessageTestCase> HttpProtocolUnitTestGenerator<T>.renderCo
         }
         writer.addImport(staticProviderSymbol)
         writer.addImport(credentialsSymbol)
-        writer.write("val credentials = Credentials(\$S, \$S)", "AKID", "SECRET")
+        writer.write("val credentials = Credentials(#S, #S)", "AKID", "SECRET")
         writer.write("credentialsProvider = StaticCredentialsProvider(credentials)")
     }
 

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/restjson/RestJsonErrorFeature.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/restjson/RestJsonErrorFeature.kt
@@ -21,7 +21,7 @@ class RestJsonErrorFeature(
             val deserializerName = "${symbol.name}Deserializer"
             val httpStatusCode: Int? = errShape.getTrait(HttpErrorTrait::class.java).map { it.code }.orElse(null)
             if (httpStatusCode != null) {
-                writer.write("register(code = \$S, deserializer = $deserializerName(), httpStatusCode = $httpStatusCode)", code)
+                writer.write("register(code = #S, deserializer = $deserializerName(), httpStatusCode = $httpStatusCode)", code)
             }
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
/story/show/177020506

*Description of changes:*
Change CodeWriter expression start symbol from `$` to `#` which requires less escaping around `$` which is special cased in Kotlin strings already.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
