### PR TITLE
Filter invalid characters from SDK name.

### DIFF
--- a/codegen/protocol-tests/smithy-build.json
+++ b/codegen/protocol-tests/smithy-build.json
@@ -13,8 +13,10 @@
       "plugins": {
         "kotlin-codegen": {
           "service": "aws.protocoltests.restjson#RestJson",
-          "module": "aws.sdk.kotlin.runtime.protocoltest.awsrestjson",
-          "moduleVersion": "1.0",
+          "package" : {
+            "name": "aws.sdk.kotlin.runtime.protocoltest.awsrestjson",
+            "version": "1.0"
+          },
           "build":  {
               "rootProject": true,
               "optInAnnotations": ["software.aws.clientrt.util.InternalAPI", "aws.sdk.kotlin.runtime.InternalSdkApi"]
@@ -34,8 +36,10 @@
       "plugins": {
         "kotlin-codegen": {
           "service": "aws.protocoltests.json10#JsonRpc10",
-          "module": "aws.sdk.kotlin.runtime.protocoltest.awsjson10",
-          "moduleVersion": "1.0",
+          "package" : {
+            "name": "aws.sdk.kotlin.runtime.protocoltest.awsjson10",
+            "version": "1.0"
+          },
           "build":  {
             "rootProject": true,
             "optInAnnotations": ["software.aws.clientrt.util.InternalAPI", "aws.sdk.kotlin.runtime.InternalSdkApi"]
@@ -55,8 +59,10 @@
       "plugins": {
         "kotlin-codegen": {
           "service": "aws.protocoltests.json#JsonProtocol",
-          "module": "aws.sdk.kotlin.runtime.protocoltest.awsjson11",
-          "moduleVersion": "1.0",
+          "package" : {
+            "name": "aws.sdk.kotlin.runtime.protocoltest.awsjson11",
+            "version": "1.0"
+          },
           "build":  {
             "rootProject": true,
             "optInAnnotations": ["software.aws.clientrt.util.InternalAPI", "aws.sdk.kotlin.runtime.InternalSdkApi"]

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/AwsHttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/AwsHttpBindingProtocolGenerator.kt
@@ -25,9 +25,8 @@ abstract class AwsHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
         .build()
 
     override fun getHttpProtocolClientGenerator(ctx: ProtocolGenerator.GenerationContext): HttpProtocolClientGenerator {
-        val rootNamespace = ctx.settings.moduleName
         val features = getHttpFeatures(ctx)
-        return AwsHttpProtocolClientGenerator(ctx, rootNamespace, features, getProtocolHttpBindingResolver(ctx))
+        return AwsHttpProtocolClientGenerator(ctx, features, getProtocolHttpBindingResolver(ctx))
     }
 
     override fun getHttpFeatures(ctx: ProtocolGenerator.GenerationContext): List<HttpFeature> {

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/AwsHttpProtocolClientGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/AwsHttpProtocolClientGenerator.kt
@@ -19,10 +19,9 @@ import software.amazon.smithy.model.shapes.OperationShape
  */
 class AwsHttpProtocolClientGenerator(
     ctx: ProtocolGenerator.GenerationContext,
-    rootNamespace: String,
     features: List<HttpFeature>,
     httpBindingResolver: HttpBindingResolver
-) : HttpProtocolClientGenerator(ctx, rootNamespace, features, httpBindingResolver) {
+) : HttpProtocolClientGenerator(ctx, features, httpBindingResolver) {
 
     override fun render(writer: KotlinWriter) {
         writer.write("\n\n")

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/EndpointResolverFeature.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/EndpointResolverFeature.kt
@@ -25,7 +25,7 @@ class EndpointResolverFeature(private val ctx: ProtocolGenerator.GenerationConte
         // generated symbol
         val defaultResolverSymbol = buildSymbol {
             name = "DefaultEndpointResolver"
-            namespace = "${ctx.settings.moduleName}.internal"
+            namespace = "${ctx.settings.pkg.name}.internal"
         }
 
         writer.addImport(resolverFeatureSymbol)

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/EndpointResolverGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/EndpointResolverGenerator.kt
@@ -19,7 +19,7 @@ import java.util.*
 class EndpointResolverGenerator(private val endpointData: ObjectNode) {
 
     fun render(ctx: ProtocolGenerator.GenerationContext) {
-        ctx.delegator.useFileWriter("DefaultEndpointResolver.kt", "${ctx.settings.moduleName}.internal") {
+        ctx.delegator.useFileWriter("DefaultEndpointResolver.kt", "${ctx.settings.pkg.name}.internal") {
             renderResolver(it)
             renderInternalEndpointsModel(ctx, it)
         }

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/GradleGenerator.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/GradleGenerator.kt
@@ -38,8 +38,8 @@ class GradleGenerator : KotlinIntegration {
         }
 
         writer.write("")
-        if (ctx.settings.moduleDescription.isNotEmpty()) {
-            writer.write("description = #S", ctx.settings.moduleDescription)
+        if (!ctx.settings.pkg.description.isNullOrEmpty()) {
+            writer.write("description = #S", ctx.settings.pkg.description)
         }
 
         val dependencies = delegator.dependencies.mapNotNull { it.properties["dependency"] as? KotlinDependency }.distinct()

--- a/codegen/smithy-aws-kotlin-codegen/src/test/kotlin/TestUtils.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/test/kotlin/TestUtils.kt
@@ -35,11 +35,13 @@ class MockHttpProtocolGenerator : HttpBindingProtocolGenerator() {
 
 // Produce a GenerationContext given a model, it's expected namespace and service name.
 fun Model.generateTestContext(namespace: String, serviceName: String): ProtocolGenerator.GenerationContext {
+    val packageNode = Node.objectNode().withMember("name", Node.from("test"))
+        .withMember("version", Node.from("1.0.0"))
+
     val settings = KotlinSettings.from(
         this,
         Node.objectNodeBuilder()
-            .withMember("module", Node.from("test"))
-            .withMember("moduleVersion", Node.from("1.0.0"))
+            .withMember("package", packageNode)
             .build()
     )
     val provider: SymbolProvider = KotlinCodegenPlugin.createSymbolProvider(this, namespace, serviceName)


### PR DESCRIPTION


*Issue #, if available:* /story/show/176972723

Companion PR: https://github.com/awslabs/smithy-kotlin/pull/72

This PR replaces https://github.com/awslabs/aws-sdk-kotlin/pull/70

*Description of changes:*
* Refactor smithy settings to better model package namespace.

## Testing Done
* Verify `rds-data` does not have issue w/ package name 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
