### PR TITLE
Implement serde object/field codegen for xml format

### DIFF
--- a/client-runtime/protocols/rest-json/common/test/aws/sdk/kotlin/runtime/restjson/RestJsonErrorTest.kt
+++ b/client-runtime/protocols/rest-json/common/test/aws/sdk/kotlin/runtime/restjson/RestJsonErrorTest.kt
@@ -22,8 +22,8 @@ import software.aws.clientrt.http.request.HttpRequestBuilder
 import software.aws.clientrt.http.response.HttpResponse
 import software.aws.clientrt.http.response.header
 import software.aws.clientrt.serde.*
-import software.aws.clientrt.serde.json.JsonSerialName
 import software.aws.clientrt.serde.json.JsonSerdeProvider
+import software.aws.clientrt.serde.json.JsonSerialName
 import kotlin.test.*
 
 @OptIn(ExperimentalStdlibApi::class)

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/awsjson/AwsJsonHttpBindingResolver.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/awsjson/AwsJsonHttpBindingResolver.kt
@@ -1,7 +1,6 @@
 package aws.sdk.kotlin.codegen.awsjson
 
-import software.amazon.smithy.kotlin.codegen.expectTrait
-import software.amazon.smithy.kotlin.codegen.hasTrait
+import software.amazon.smithy.kotlin.codegen.*
 import software.amazon.smithy.kotlin.codegen.integration.HttpBindingDescriptor
 import software.amazon.smithy.kotlin.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.kotlin.codegen.integration.ProtocolGenerator
@@ -74,7 +73,7 @@ class AwsJsonHttpBindingResolver(
         }
     }
 
-    // TODO ~ link to future awsJson spec which describes this content type
+    // See https://awslabs.github.io/smithy/1.0/spec/aws/aws-json-1_0-protocol.html#protocol-behaviors
     override fun determineRequestContentType(operationShape: OperationShape): String = defaultContentType
 
     override fun determineTimestampFormat(


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/smithy-kotlin/issues/148

Companion PR: https://github.com/awslabs/smithy-kotlin/pull/239

*Description of changes:*
* Update RestXml protocol class to provide xml specific serde obj/field codegen.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
