### PR TITLE
refactor: generate clients into ignored src folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build/
 *.iml
 .idea/
 local.properties
+# ignore generated files
+services/*/generated-src
+services/*/build.gradle.kts

--- a/codegen/sdk/build.gradle.kts
+++ b/codegen/sdk/build.gradle.kts
@@ -195,8 +195,12 @@ task("stageSdks") {
         discoveredServices.forEach {
             logger.info("copying ${it.outputDir} to ${it.destinationDir}")
             copy {
-                from(it.outputDir)
-                into(it.destinationDir)
+                from("${it.outputDir}/src")
+                into("${it.destinationDir}/generated-src")
+            }
+            copy {
+                from("${it.outputDir}/build.gradle.kts")
+                into("${it.destinationDir}")
             }
         }
     }

--- a/services/build.gradle.kts
+++ b/services/build.gradle.kts
@@ -27,6 +27,10 @@ subprojects {
     // have generated sdk's opt-in to internal runtime features
     kotlin.sourceSets.all {
         experimentalAnnotations.forEach { languageSettings.useExperimentalAnnotation(it) }
+
+        if (name == "main") {
+            kotlin.srcDir("generated-src/main/kotlin")
+        }
     }
 
     tasks.test {


### PR DESCRIPTION
*Description of changes:*
Small cleanup commit. Changes the folder generated sources are copied into and `.gitignore` updated to ignore generated files/folders.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
