### PR TITLE
fix: use an explicit smithy-cli version

### DIFF
--- a/codegen/protocol-tests/build.gradle.kts
+++ b/codegen/protocol-tests/build.gradle.kts
@@ -10,8 +10,15 @@ plugins {
 
 description = "Smithy protocol test suite"
 
-val smithyVersion: String by project
+buildscript {
+    val smithyVersion: String by project
+    dependencies {
+        classpath("software.amazon.smithy:smithy-cli:$smithyVersion")
+    }
+}
 
+
+val smithyVersion: String by project
 dependencies {
     implementation("software.amazon.smithy:smithy-aws-protocol-tests:$smithyVersion")
     implementation(project(":codegen:smithy-aws-kotlin-codegen"))

--- a/codegen/sdk/build.gradle.kts
+++ b/codegen/sdk/build.gradle.kts
@@ -22,6 +22,7 @@ buildscript {
     val smithyVersion: String by project
     dependencies {
         classpath("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
+        classpath("software.amazon.smithy:smithy-cli:$smithyVersion")
     }
 }
 


### PR DESCRIPTION
Use explict `smithy-cli` version. Had a build issue locally where the detected version suddenly went to `1.7.0` which caused a build failure:

```
> Configure project :codegen:sdk                                                                                                            
(scanned and found a Smithy CLI version 1.7.0. You will need to add an explicit dependency on smithy-model if publishing a JAR)             
Building Smithy model sources: []                                                                                                           
Loading Smithy configs: [/Users/todaaron/sandbox/brazil/workspace/src/AwsSdkKotlinBuildTools/release/repos/aws-sdk-kotlin/codegen/sdk/smithy
-build.json]                                                                                                                                
Validation result: 0 ERROR(s), 0 DANGER(s), 0 WARNING(s), 0 NOTE(s)                                                                         
Validated 284 shapes in model                                                                                                               
Completed projection source (284 shapes): /Users/todaaron/sandbox/brazil/workspace/src/AwsSdkKotlinBuildTools/release/repos/aws-sdk-kotlin/c
odegen/sdk/build/smithyprojections/sdk/source                                                                                               
executing kotlin codegen                                                                                                                    
Projection dynamodb.2012-08-10 failed: java.lang.NoSuchMethodError: 'java.util.Map software.amazon.smithy.model.shapes.ServiceShape.getRenam
e()'                                                                                                                                        
software.amazon.smithy.model.transform.plugins.CleanServiceRenames.lambda$onRemove$1(CleanServiceRenames.java:41)                           
java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1603)                                                              
java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:658)                                                       
software.amazon.smithy.model.transform.plugins.CleanServiceRenames.onRemove(CleanServiceRenames.java:39)                                    
software.amazon.smithy.model.transform.RemoveShapes.transform(RemoveShapes.java:61)                                                         
software.amazon.smithy.model.transform.ModelTransformer.removeShapes(ModelTransformer.java:125)                                             
software.amazon.smithy.model.transform.ScrubTraitDefinitions.transform(ScrubTraitDefinitions.java:68)                                       
software.amazon.smithy.model.transform.ModelTransformer.scrubTraitDefinitions(ModelTransformer.java:400)                                    
software.amazon.smithy.model.transform.ModelTransformer.getModelWithoutTraitShapes(ModelTransformer.java:433)                               
software.amazon.smithy.model.transform.ModelTransformer.getModelWithoutTraitShapes(ModelTransformer.java:411)                               
software.amazon.smithy.kotlin.codegen.CodegenVisitor.execute(CodegenVisitor.kt:94)                                                          
software.amazon.smithy.kotlin.codegen.KotlinCodegenPlugin.execute(KotlinCodegenPlugin.kt:21)                                                
software.amazon.smithy.build.SmithyBuildImpl.applyPlugin(SmithyBuildImpl.java:376)                                                          
software.amazon.smithy.build.SmithyBuildImpl.applyProjection(SmithyBuildImpl.java:313)                                                      
software.amazon.smithy.build.SmithyBuildImpl.executeSerialProjection(SmithyBuildImpl.java:223)                                              
software.amazon.smithy.build.SmithyBuildImpl.lambda$applyAllProjections$5(SmithyBuildImpl.java:188)                                         
java.base/java.util.concurrent.ForkJoinTask$AdaptedCallable.exec(ForkJoinTask.java:1448)                                                    
java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)                                                                   
java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)                                                  
java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)                                                                    
java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)                                                               
java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)                                                      
Smithy built 1 projection(s), 3 plugin(s), and 3 artifacts                                                                                  
The following 1 Smithy build projection(s) failed: [dynamodb.2012-08-10]      
```

I'm not sure how this version is detected since we set all of our smithy versions to `1.6.1` and everything was building fine and suddenly didn't so there was something implicit but waiting for clarification from smithy team.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
