### PR TITLE
fix: initialization order

### DIFF
--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/AwsKotlinDependency.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/AwsKotlinDependency.kt
@@ -43,13 +43,16 @@ object AwsKotlinDependency {
 }
 
 // remap aws-sdk-kotlin dependencies to project notation
-private val sameProjectDeps = mapOf(
-    AwsKotlinDependency.AWS_CLIENT_RT_CORE to """project(":client-runtime:aws-client-rt")""",
-    AwsKotlinDependency.AWS_CLIENT_RT_HTTP to """project(":client-runtime:protocols:http")""",
-    AwsKotlinDependency.AWS_CLIENT_RT_AUTH to """project(":client-runtime:auth")""",
-    AwsKotlinDependency.AWS_CLIENT_RT_REGIONS to """project(":client-runtime:regions")""",
-    AwsKotlinDependency.AWS_CLIENT_RT_JSON_PROTOCOLS to """project(":client-runtime:protocols:aws-json-protocols")"""
-)
+// NOTE: the lazy wrapper is required here, see: https://github.com/awslabs/aws-sdk-kotlin/issues/95
+private val sameProjectDeps: Map<KotlinDependency, String> by lazy {
+    mapOf(
+        AwsKotlinDependency.AWS_CLIENT_RT_CORE to """project(":client-runtime:aws-client-rt")""",
+        AwsKotlinDependency.AWS_CLIENT_RT_HTTP to """project(":client-runtime:protocols:http")""",
+        AwsKotlinDependency.AWS_CLIENT_RT_AUTH to """project(":client-runtime:auth")""",
+        AwsKotlinDependency.AWS_CLIENT_RT_REGIONS to """project(":client-runtime:regions")""",
+        AwsKotlinDependency.AWS_CLIENT_RT_JSON_PROTOCOLS to """project(":client-runtime:protocols:aws-json-protocols")"""
+    )
+}
 
 internal fun KotlinDependency.dependencyNotation(allowProjectNotation: Boolean = true): String {
     val dep = this


### PR DESCRIPTION
*Issue #, if available:*
fixes: #95 

*Description of changes:*
lazily build the map of aws kotlin dependencies to fix initialization order. This was causing the generated dependency notation to be "wrong".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
