### PR TITLE
fix broken link due to markdown formatting

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -49,7 +49,7 @@ repositories {
 
 4. Add services to your project
 
-Services available for testing: cognitoidentityprovider, dynamodb, kms, lambda, polly, secretsmanager, translate
+Services available for testing: `cognitoidentityprovider`, `dynamodb`, `kms`, `lambda`, `polly`, `secretsmanager`, `translate`
 
 ```kt
 
@@ -81,5 +81,5 @@ val client = DynamodbClient { region = "us-east-2" }
 
 ## Giving Feedback
 
-* Slack - Join `[#aws-sdk-kotlin-interest](https://amzn-aws.slack.com/archives/C0182UWTQJJ)` to get help, share feedback, and get updates on SDK development.
+* Slack - Join [#aws-sdk-kotlin-interest](https://amzn-aws.slack.com/archives/C0182UWTQJJ) to get help, share feedback, and get updates on SDK development.
 * Submit [issues](https://github.com/awslabs/aws-sdk-kotlin/issues)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
1.  Code formatting breaks the slack link.  This removes the formatting so the link works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
