### PR TITLE
Add logging dependencies to getting started snippet

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -57,7 +57,7 @@ val awsKotlinSdkVersion = "0.1.0-M0"
 // OR put it in gradle.properties
 // val awsKotlinSdkVersion by project
 
-dependencies {    
+dependencies {
     implementation(kotlin("stdlib"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
     
@@ -67,8 +67,8 @@ dependencies {
     implementation("aws.sdk.kotlin:dynamodb:$awsKotlinSdkVersion")
     
     // The following will cause SDK logs to emit to the console:
-    testImplementation("org.slf4j:slf4j-api:1.7.30")
-    testImplementation("org.slf4j:slf4j-simple:1.7.30")
+    implementation("org.slf4j:slf4j-api:1.7.30")
+    implementation("org.slf4j:slf4j-simple:1.7.30")
 }
 ```
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* Add logging dependencies to getting started snippet.  If customers add this by default when evaluating the SDK we will get logs that may be helpful in diagnosing problems.


## Testing done
* Added the dependencies to protocol tests (that had no logs) and found that the change worked as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
