### PR TITLE
Update GettingStarted.md

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -55,7 +55,7 @@ Services available for testing: `cognitoidentityprovider`, `dynamodb`, `kms`, `l
 
 val awsKotlinSdkVersion = "0.1.0-M0"
 // OR put it in gradle.properties
-// val awsKotlinSdkVersion by project
+// val awsKotlinSdkVersion: String by project
 
 dependencies {
     implementation(kotlin("stdlib"))


### PR DESCRIPTION
The example using gradle.properties to specify the SDK version needs to include the type, otherwise it is not valid.

E.g.: https://github.com/gradle/kotlin-dsl-samples/issues/535#issuecomment-388342524