### PR TITLE
fix: explicitly set jvm target compatibility

### DIFF
--- a/services/build.gradle.kts
+++ b/services/build.gradle.kts
@@ -5,7 +5,7 @@
  */
 plugins {
     kotlin("jvm")
-    `maven`
+    maven
     `maven-publish`
     id("org.jetbrains.dokka")
 }
@@ -43,6 +43,18 @@ subprojects {
         }
     }
 
+
+    // this is the default but it's better to be explicit (e.g. it may change in Kotlin 1.5)
+    tasks.compileKotlin {
+        kotlinOptions.jvmTarget = "1.6"
+    }
+    tasks.compileTestKotlin {
+        kotlinOptions.jvmTarget = "1.6"
+    }
+
+    // FIXME - we can remove this when we implement generated services as multiplatform.
+    setOutgoingVariantMetadata()
+
     val sourcesJar by tasks.creating(Jar::class) {
         group = "publishing"
         description = "Assembles Kotlin sources jar"
@@ -64,4 +76,14 @@ subprojects {
     }
 
     apply(from = rootProject.file("gradle/publish.gradle"))
+}
+
+
+// fixes outgoing variant metadata: https://github.com/awslabs/smithy-kotlin/issues/258
+fun Project.setOutgoingVariantMetadata() {
+    tasks.withType<JavaCompile>() {
+        val javaVersion = JavaVersion.VERSION_1_8.toString()
+        sourceCompatibility = javaVersion
+        targetCompatibility = javaVersion
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

awslabs/smithy-kotlin#258

*Description of changes:*
Explicilty set the java source/target compatibility to 1.8 so that the outgoing gradle variant metadata isn't inferred from the JVM version gradle is running with. See: [Gradle JVM Default Attributes](https://docs.gradle.org/current/userguide/variant_attributes.html#sub:jvm_default_attributes).


I'm not positive this is the right way to fix this as I'm not an expert on gradle variants or the possible interactions between the kotlin plugin and the java plugin as far as source/target compatibility. At any rate this is likely temporary anyway as KMP handles this slightly differently but our services are generated as normal Kotlin JVM projects (for now). 1.8 was chosen based on what amplify-android currently targets in their build file. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
