### PR TITLE
Add codegen group to codegen tasks in sdk

### DIFF
--- a/codegen/sdk/build.gradle.kts
+++ b/codegen/sdk/build.gradle.kts
@@ -157,6 +157,7 @@ fun String.kotlinNamespace(): String = split(".")
 
 // Generate smithy-build.json as first step in build task
 task("generateSmithyBuild") {
+    group = "codegen"
     description = "generate smithy-build.json"
     doFirst {
         projectDir.resolve("smithy-build.json").writeText(generateSmithyBuild(discoveredServices))
@@ -164,6 +165,7 @@ task("generateSmithyBuild") {
 }
 
 tasks.create<SmithyBuild>("generateSdk") {
+    group = "codegen"
     // ensure the generated clients use the same version of the runtime as the aws client-runtime
     val smithyKotlinVersion: String by project
     doFirst {
@@ -190,6 +192,7 @@ val AwsService.destinationDir: String
     }
 
 task("stageSdks") {
+    group = "codegen"
     description = "relocate generated SDK(s) from build directory to services/ dir"
     dependsOn("generateSdk")
     doLast {
@@ -208,6 +211,7 @@ task("stageSdks") {
 }
 
 tasks.create("bootstrap") {
+    group = "codegen"
     description = "Generate AWS SDK's and register them with the build"
 
     dependsOn(tasks["generateSdk"])


### PR DESCRIPTION
*Issue #, if available:* N/A

NOTE: I'm unaware of anything that would break by changing task category to 'codegen' but LMK if there is something that needs to be changed elsewhere...

*Description of changes:*
* This simply specifies a category for custom codegen tasks we have in our Kotlin SDK codegen module.  It seperates these tasks from "other" and makes it easier to find for customers that use UI tooling to see tasks.  Example:

![image](https://user-images.githubusercontent.com/65979407/116165204-3941ca80-a6b0-11eb-9d54-0de300149161.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
