### PR TITLE
fix: unify serde exceptions

### DIFF
--- a/client-runtime/protocols/aws-xml-protocols/common/src/aws/sdk/kotlin/runtime/protocol/xml/RestXmlErrorDeserializer.kt
+++ b/client-runtime/protocols/aws-xml-protocols/common/src/aws/sdk/kotlin/runtime/protocol/xml/RestXmlErrorDeserializer.kt
@@ -78,7 +78,7 @@ internal object ErrorResponseDeserializer {
             }
 
             XmlErrorResponse(xmlError, requestId ?: xmlError?.requestId)
-        } catch (e: DeserializerStateException) {
+        } catch (e: DeserializationException) {
             null // return so an appropriate exception type can be instantiated above here.
         }
     }
@@ -118,7 +118,7 @@ internal object XmlErrorDeserializer {
             }
 
             XmlError(requestId, code, message)
-        } catch (e: DeserializerStateException) {
+        } catch (e: DeserializationException) {
             null // return so an appropriate exception type can be instantiated above here.
         }
     }


### PR DESCRIPTION
*Issue #, if available:* awslabs/smithy-kotlin#193

*Companion pr:* awslabs/smithy-kotlin#315

*Description of changes:* Remove all the protocol-specific exceptions in favor of the top-level common ones.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.