### PR TITLE
fix: use the original service shape name to construct x-amz-target header

### DIFF
--- a/client-runtime/protocols/aws-json-protocols/common/src/aws/sdk/kotlin/runtime/protocol/json/AwsJsonProtocol.kt
+++ b/client-runtime/protocols/aws-json-protocols/common/src/aws/sdk/kotlin/runtime/protocol/json/AwsJsonProtocol.kt
@@ -22,9 +22,15 @@ import software.aws.clientrt.util.get
  */
 @InternalSdkApi
 public class AwsJsonProtocol(config: Config) : Feature {
-    private val version: String = requireNotNull(config.version) { "AWS JSON Protocol version must be specified" }
+    private val serviceShapeName: String = requireNotNull(config.serviceShapeName) { "AWS JSON protocol service name must be specified" }
+    private val version: String = requireNotNull(config.version) { "AWS JSON protocol version must be specified" }
 
     public class Config {
+        /**
+         * The original service (shape) name
+         */
+        public var serviceShapeName: String? = null
+
         /**
          * The protocol version e.g. "1.0"
          */
@@ -44,11 +50,10 @@ public class AwsJsonProtocol(config: Config) : Feature {
         operation.execution.mutate.intercept { req, next ->
             val context = req.context
             // required context elements
-            val serviceName = context[SdkClientOption.ServiceName]
             val operationName = context[SdkClientOption.OperationName]
 
             // see: https://awslabs.github.io/smithy/1.0/spec/aws/aws-json-1_0-protocol.html#protocol-behaviors
-            req.subject.headers.append("X-Amz-Target", "$serviceName.$operationName")
+            req.subject.headers.append("X-Amz-Target", "$serviceShapeName.$operationName")
             req.subject.headers.setMissing("Content-Type", "application/x-amz-json-$version")
 
             if (req.subject.body is HttpBody.Empty) {

--- a/client-runtime/protocols/aws-json-protocols/common/test/aws/sdk/kotlin/runtime/protocol/json/AwsJsonProtocolTest.kt
+++ b/client-runtime/protocols/aws-json-protocols/common/test/aws/sdk/kotlin/runtime/protocol/json/AwsJsonProtocolTest.kt
@@ -42,6 +42,7 @@ class AwsJsonProtocolTest {
         }
         val client = sdkHttpClient(mockEngine)
         op.install(AwsJsonProtocol) {
+            serviceShapeName = "FooService_blah"
             version = "1.1"
         }
 
@@ -49,7 +50,9 @@ class AwsJsonProtocolTest {
         val request = op.context[HttpOperationContext.HttpCallList].last().request
 
         assertEquals("application/x-amz-json-1.1", request.headers["Content-Type"])
-        assertEquals("FooService.Bar", request.headers["X-Amz-Target"])
+        // ensure we use the original shape id name, NOT the one from the context
+        // see: https://github.com/awslabs/smithy-kotlin/issues/316
+        assertEquals("FooService_blah.Bar", request.headers["X-Amz-Target"])
     }
 
     @Test
@@ -72,6 +75,7 @@ class AwsJsonProtocolTest {
         }
         val client = sdkHttpClient(mockEngine)
         op.install(AwsJsonProtocol) {
+            serviceShapeName = "FooService"
             version = "1.1"
         }
 
@@ -109,6 +113,7 @@ class AwsJsonProtocolTest {
         }
         val client = sdkHttpClient(mockEngine)
         op.install(AwsJsonProtocol) {
+            serviceShapeName = "FooService"
             version = "1.1"
         }
 

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/protocols/AwsJson1_0.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/protocols/AwsJson1_0.kt
@@ -28,7 +28,7 @@ class AwsJson1_0 : AwsHttpBindingProtocolGenerator() {
     override fun getDefaultHttpMiddleware(ctx: ProtocolGenerator.GenerationContext): List<ProtocolMiddleware> {
         val httpMiddleware = super.getDefaultHttpMiddleware(ctx)
         val awsJsonMiddleware = listOf(
-            AwsJsonProtocolMiddleware("1.0"),
+            AwsJsonProtocolMiddleware(ctx.settings.service, "1.0"),
             AwsJsonModeledExceptionsMiddleware(ctx, getProtocolHttpBindingResolver(ctx))
         )
 

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/protocols/AwsJson1_1.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/protocols/AwsJson1_1.kt
@@ -33,7 +33,7 @@ class AwsJson1_1 : AwsHttpBindingProtocolGenerator() {
     override fun getDefaultHttpMiddleware(ctx: ProtocolGenerator.GenerationContext): List<ProtocolMiddleware> {
         val httpMiddleware = super.getDefaultHttpMiddleware(ctx)
         val awsJsonFeatures = listOf(
-            AwsJsonProtocolMiddleware("1.1"),
+            AwsJsonProtocolMiddleware(ctx.settings.service, "1.1"),
             AwsJsonModeledExceptionsMiddleware(ctx, getProtocolHttpBindingResolver(ctx))
         )
 

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/protocols/json/AwsJsonProtocolMiddleware.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/protocols/json/AwsJsonProtocolMiddleware.kt
@@ -10,12 +10,16 @@ import software.amazon.smithy.kotlin.codegen.core.KotlinWriter
 import software.amazon.smithy.kotlin.codegen.model.buildSymbol
 import software.amazon.smithy.kotlin.codegen.model.namespace
 import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolMiddleware
+import software.amazon.smithy.model.shapes.ShapeId
 
 /**
  * Configure the AwsJsonProtocol middleware
  * @param protocolVersion The AWS JSON protocol version (e.g. "1.0", "1.1", etc)
  */
-class AwsJsonProtocolMiddleware(private val protocolVersion: String) : ProtocolMiddleware {
+class AwsJsonProtocolMiddleware(
+    private val serviceShapeId: ShapeId,
+    private val protocolVersion: String
+) : ProtocolMiddleware {
     override val name: String = "AwsJsonProtocol"
 
     override fun addImportsAndDependencies(writer: KotlinWriter) {
@@ -29,6 +33,7 @@ class AwsJsonProtocolMiddleware(private val protocolVersion: String) : ProtocolM
     }
 
     override fun renderConfigure(writer: KotlinWriter) {
+        writer.write("serviceShapeName = #S", serviceShapeId.name)
         writer.write("version = #S", protocolVersion)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
fixes: https://github.com/awslabs/smithy-kotlin/issues/316

*Description:*
Fixes the aws json middleware to use the original service shape name from the model to construct the `x-amz-target` header. See ticket for details/origin.

I've opted to no longer use `SdkClientOption.ServiceName` for this purpose and instead just pass it explicitly to the middleware. We should probably make some of the existing `SdkClientOption(s)` have `@InternalApi` annotations or move them to a different interface. They aren't necessarily meant to be overridden by customers/users and we rely on them to mean a specific thing. Which brings me to my next point of we should clarify exactly what those context options carry. Service name was changed to carry the `sdkId` rather than the original shape name. We probably need this to be consistent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
