### PR TITLE
In clean task, remove generated files from /services source tree.

### DIFF
--- a/codegen/sdk/build.gradle.kts
+++ b/codegen/sdk/build.gradle.kts
@@ -235,6 +235,10 @@ tasks.create<SmithyBuild>("generateSdk") {
 // Remove generated model file for clean
 tasks["clean"].doFirst {
     delete("smithy-build.json")
+    discoveredServices.forEach {
+        delete("${it.destinationDir}/generated-src")
+        delete("${it.destinationDir}/build.gradle.kts")
+    }
 }
 
 val AwsService.outputDir: String


### PR DESCRIPTION
*Issue #, if available:* N/A

When working on codegen changes I often like to run the `bootstrap` task to test out how my changes work out in codegen.  Now that we are mixing generated files and repo files in the `/services` tree it's not a simple to clean things up to ensure that some errant files generated in one build do not stick around for another build.  This change causes all generated source files to be removed in the clean task so that stale files won't stick around.

I opted to repeat the file paths due to rule of 3.

*Description of changes:*
* `clean` task of `sdk` module will now delete generated sources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
