### PR TITLE
feat: add Accept header to API Gateway requests

### DIFF
--- a/codegen/protocol-tests/build.gradle.kts
+++ b/codegen/protocol-tests/build.gradle.kts
@@ -32,7 +32,10 @@ val enabledProtocols = listOf(
     ProtocolTest("aws-restjson", "aws.protocoltests.restjson#RestJson"),
     ProtocolTest("aws-restxml", "aws.protocoltests.restxml#RestXml"),
     ProtocolTest("aws-restxml-xmlns", "aws.protocoltests.restxml.xmlns#RestXmlWithNamespace"),
-    ProtocolTest("aws-query", "aws.protocoltests.query#AwsQuery")
+    ProtocolTest("aws-query", "aws.protocoltests.query#AwsQuery"),
+
+    // service specific tests
+    ProtocolTest("apigateway", "com.amazonaws.apigateway#BackplaneControlService")
 )
 
 // This project doesn't produce a JAR.

--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/customization/apigateway/ApiGatewayAddAcceptHeader.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/customization/apigateway/ApiGatewayAddAcceptHeader.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package aws.sdk.kotlin.codegen.customization.apigateway
+
+import aws.sdk.kotlin.codegen.protocols.middleware.MutateHeadersMiddleware
+import aws.sdk.kotlin.codegen.sdkId
+import software.amazon.smithy.kotlin.codegen.KotlinSettings
+import software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+import software.amazon.smithy.kotlin.codegen.model.expectShape
+import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolGenerator
+import software.amazon.smithy.kotlin.codegen.rendering.protocol.ProtocolMiddleware
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.ServiceShape
+
+/**
+ * Adds a middleware that sets the "Accept" header to "application/json" for all requests
+ */
+class ApiGatewayAddAcceptHeader : KotlinIntegration {
+
+    override fun enabledForService(model: Model, settings: KotlinSettings) =
+        model.expectShape<ServiceShape>(settings.service).sdkId.equals("API Gateway", ignoreCase = true)
+
+    private val addAcceptHeaderMiddleware = MutateHeadersMiddleware(extraHeaders = mapOf("Accept" to "application/json"))
+
+    override fun customizeMiddleware(
+        ctx: ProtocolGenerator.GenerationContext,
+        resolved: List<ProtocolMiddleware>
+    ): List<ProtocolMiddleware> {
+        return resolved + addAcceptHeaderMiddleware
+    }
+}

--- a/codegen/smithy-aws-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/resources/META-INF/services/software.amazon.smithy.kotlin.codegen.integration.KotlinIntegration
@@ -4,3 +4,4 @@ aws.sdk.kotlin.codegen.AwsServiceConfigIntegration
 aws.sdk.kotlin.codegen.customization.s3.S3SigningConfig
 aws.sdk.kotlin.codegen.customization.s3.S3ErrorMetadataIntegration
 aws.sdk.kotlin.codegen.customization.s3.GetBucketLocationDeserializerIntegration
+aws.sdk.kotlin.codegen.customization.apigateway.ApiGatewayAddAcceptHeader


### PR DESCRIPTION
## Issue \#
closes smithy-kotlin#157

## Description of changes
Registers a default middleware that populates the `Accept` header for all API Gateway requests. Protocol [tests](https://github.com/awslabs/smithy/blob/main/smithy-aws-protocol-tests/model/restJson1/services/apigateway.smithy) for this behavior are now enabled as well.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
