### PR TITLE
fix: escape model-extra files for Windows

### DIFF
--- a/codegen/sdk/build.gradle.kts
+++ b/codegen/sdk/build.gradle.kts
@@ -78,7 +78,7 @@ fun generateSmithyBuild(services: List<AwsService>): String {
         val absModelPath = service.modelFile.absolutePath.replace("\\", "\\\\")
         val importPaths = mutableListOf(absModelPath)
         if (file(service.modelExtrasDir).exists()) {
-            importPaths.add(service.modelExtrasDir)
+            importPaths.add(service.modelExtrasDir.replace("\\", "\\\\"))
         }
         val imports = importPaths.joinToString { "\"$it\"" }
 


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

On Windows machines, models with extras aren't properly escaped (as the model file itself is on L78).

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.