### PR TITLE
Fix typo to codegen filename so s3 service compiles

### DIFF
--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/customization/s3/S3ErrorMetadataIntegration.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/customization/s3/S3ErrorMetadataIntegration.kt
@@ -25,7 +25,7 @@ class S3ErrorMetadataIntegration : KotlinIntegration {
 
     override fun writeAdditionalFiles(ctx: CodegenContext, delegator: KotlinDelegator) {
 
-        delegator.useFileWriter("S3ErrorMetadata", "${ctx.settings.pkg.name}.model") { writer ->
+        delegator.useFileWriter("S3ErrorMetadata.kt", "${ctx.settings.pkg.name}.model") { writer ->
             writer.addImport(AwsRuntimeTypes.Core.AwsErrorMetadata)
             writer.addImport(RuntimeTypes.Utils.AttributeKey)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \# N/A
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
Small fix to write the file extension so the compiler picks up the file at build time.

## Testing done

1. notice build failure before change
2. rebuild s3 after change, no build failure.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
