### PR TITLE
chore: fix gradle build and update ci

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,10 +5,13 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
   workflow_dispatch:
 
 env:
-  BUILDER_VERSION: v0.8.0
+  BUILDER_VERSION: v0.8.22
   BUILDER_SOURCE: releases
   # host owned by CRT team to host aws-crt-builder releases. Contact their on-call with any issues
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Generated sources are not checked into the repository, you first have to generat
 
 
 ```sh
-./gradlew :codegen:sdk:bootstrap
+./gradlew --no-daemon :codegen:sdk:bootstrap
 ```
 
 NOTE: This task will respect the AWS services specified by project properties. See options below.
@@ -56,7 +56,7 @@ To see list of all projects run `./gradlew projects`
 See the [Build Properties](#build-properties) below to specify this in a config file.
 
 ```sh
-./gradlew -Paws.services=+lambda  :codegen:sdk:bootstrap
+./gradlew --no-daemon -Paws.services=+lambda  :codegen:sdk:bootstrap
 ```
 
 ##### Testing Locally

--- a/builder.json
+++ b/builder.json
@@ -6,7 +6,7 @@
         "gradlew": "{source_dir}/gradlew -p {source_dir}"
     },
     "build_steps": [
-        "{gradlew} -x test -x jvmTest -x allTests build"
+        "{gradlew} assemble"
     ],
     "test_steps": [
         "{gradlew} publishToMavenLocal",

--- a/codegen/sdk/build.gradle.kts
+++ b/codegen/sdk/build.gradle.kts
@@ -276,6 +276,8 @@ tasks.create<SmithyBuild>("generateSdk") {
     addRuntimeClasspath = true
     dependsOn(tasks["generateSmithyBuild"])
     inputs.file(projectDir.resolve("smithy-build.json"))
+    // ensure smithy-aws-kotlin-codegen is up to date
+    inputs.files(configurations.compileClasspath)
 }
 
 // Remove generated model file for clean

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ kotlin.native.ignoreDisabledTargets=true
 
 # gradle
 # FIXME - see https://github.com/Kotlin/dokka/issues/1405
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1G
+org.gradle.jvmargs=-Xmx6g -XX:MaxPermSize=6g -XX:MaxMetaspaceSize=1G
 
 # sdk
 sdkVersion=0.4.0-SNAPSHOT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A
## Description of changes
<!--- Why is this change required? What problem does it solve? -->
(fix/chore): Fixed the dependency behavior of protocol tests and SDK codegen. The smithy build (generate) tasks now depend on the runtime classpath which ensures the dependencies declared are up to date. Changes to codegen should now automatically be rebuilt when you goto (re)generate code. There is still an issue with smithy itself and caching behavior where it requires a ./gradlew --stop call but at least now you can be sure codegen is up to date when you generate.
* update crt builder version
* Ignore doc updates for CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
