### PR TITLE
chore: clean up publishing workflow

### DIFF
--- a/codegen/smithy-aws-kotlin-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-kotlin-codegen/build.gradle.kts
@@ -102,18 +102,13 @@ val sourcesJar by tasks.creating(Jar::class) {
     from(sourceSets.getByName("main").allSource)
 }
 
-if (
-    !project.hasProperty("publishGroupName") ||
-    group.toString().startsWith(project.property("publishGroupName") as String)
-) {
-    publishing {
-        publications {
-            create<MavenPublication>("codegen") {
-                from(components["java"])
-                artifact(sourcesJar)
-            }
+publishing {
+    publications {
+        create<MavenPublication>("codegen") {
+            from(components["java"])
+            artifact(sourcesJar)
         }
     }
-
-    apply(from = rootProject.file("gradle/publish.gradle"))
 }
+
+apply(from = rootProject.file("gradle/publish.gradle"))

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -3,73 +3,79 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
 // FIXME: Create a real "javadoc" JAR from the Dokka output
 tasks.register("javadocJar", Jar) {
     archiveClassifier.set("javadoc")
     from()
 }
 
-project.afterEvaluate {
-    String publishGroupName = project.findProperty("publishGroupName")
-    if (publishGroupName == null || project.group.startsWith(publishGroupName)) {
-        apply plugin: 'maven-publish'
-        apply plugin: 'signing'
-
-        publishing {
-            repositories {
-                maven { name = "testLocal"; url = "$rootProject.buildDir/m2" }
-                maven {
-                    name = "awsCodeArtifact"
-                    url = project.findProperty("codeartifact.url")
-                    credentials {
-                        username = "aws"
-                        password = project.findProperty("codeartifact.token") ?: System.getenv("CODEARTIFACT_TOKEN")
-                    }
-                }
+publishing {
+    repositories {
+        maven { name = "testLocal"; url = "$rootProject.buildDir/m2" }
+        maven {
+            name = "awsCodeArtifact"
+            url = project.findProperty("codeartifact.url")
+            credentials {
+                username = "aws"
+                password = project.findProperty("codeartifact.token") ?: System.getenv("CODEARTIFACT_TOKEN")
             }
-
-            publications.all {
-                pom {
-                    name = project.name
-                    description = project.description
-                    url = "https://github.com/awslabs/aws-sdk-kotlin"
-                    licenses {
-                        license {
-                            name = "The Apache License, Version 2.0"
-                            url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                        }
-                    }
-                    developers {
-                        developer {
-                            id = "aws-sdk-kotlin"
-                            name = "AWS SDK Kotlin Team"
-                            // TODO - team email?
-                        }
-                    }
-                    scm {
-                        connection = "scm:git:git://github.com/awslabs/aws-sdk-kotlin.git"
-                        developerConnection = "scm:git:ssh://github.com/awslabs/aws-sdk-kotlin.git"
-                        url = "https://github.com/awslabs/aws-sdk-kotlin"
-                    }
-
-                    artifact(tasks["javadocJar"])
-                }
-            }
-
-            if (project.hasProperty("signingKey") && project.hasProperty("signingPassword")) {
-                signing {
-                    useInMemoryPgpKeys(
-                            (String) project.property("signingKey"),
-                            (String) project.property("signingPassword")
-                    )
-                    sign(publications)
-                }
-            }
-        }
-
-        tasks.register('publishToAwsCodeArtifact') {
-            dependsOn 'publishAllPublicationsToAwsCodeArtifactRepository'
-            group 'publishing'
         }
     }
+
+    publications.all {
+        project.afterEvaluate {
+            pom {
+                name = project.name
+                description = project.description
+                url = "https://github.com/awslabs/aws-sdk-kotlin"
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        id = "aws-sdk-kotlin"
+                        name = "AWS SDK Kotlin Team"
+                        // TODO - team email?
+                    }
+                }
+                scm {
+                    connection = "scm:git:git://github.com/awslabs/aws-sdk-kotlin.git"
+                    developerConnection = "scm:git:ssh://github.com/awslabs/aws-sdk-kotlin.git"
+                    url = "https://github.com/awslabs/aws-sdk-kotlin"
+                }
+
+                artifact(tasks["javadocJar"])
+            }
+        }
+    }
+
+    if (project.hasProperty("signingKey") && project.hasProperty("signingPassword")) {
+        signing {
+            useInMemoryPgpKeys(
+                (String) project.property("signingKey"),
+                (String) project.property("signingPassword")
+            )
+            sign(publications)
+        }
+    }
+}
+
+tasks.register('publishToAwsCodeArtifact') {
+    dependsOn 'publishAllPublicationsToAwsCodeArtifactRepository'
+    group 'publishing'
+}
+
+def isAvailableForPublication(publication) {
+    return !project.hasProperty("publishGroupName") ||
+            publication.groupId.startsWith((String) project.property("publishGroupName"))
+}
+
+tasks.withType(AbstractPublishToMaven).all {
+    onlyIf { isAvailableForPublication(publication) }
 }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

The previous checks for group names were spread too many places and requires `afterEvaluate` blocks around too much logic. This change hopefully simplifies them into an easier-to-understand configuration.

**Note**: `afterEvaluate` is still required around POM configuration. Otherwise, name and description will not be configured properly leading to POM files which fail Nexus's correctness checks.

This is the **aws-sdk-kotlin**-specific version of smithy-kotlin#461.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.