### PR TITLE
fix: set metadata from AWS_EXECUTION_ENV

### DIFF
--- a/aws-runtime/aws-core/common/src/aws/sdk/kotlin/runtime/AwsSdkSetting.kt
+++ b/aws-runtime/aws-core/common/src/aws/sdk/kotlin/runtime/AwsSdkSetting.kt
@@ -51,4 +51,10 @@ public sealed class AwsSdkSetting<T> (
      * Configure the default region.
      */
     public object AwsRegion : AwsSdkSetting<String>("AWS_REGION", "aws.region")
+
+    /**
+     * The execution environment of the SDK user. This is automatically set in certain environments by the underlying AWS service.
+     * For example, AWS Lambda will automatically specify a runtime indicating that the SDK is being used within Lambda.
+     */
+    public object AwsExecutionEnv : AwsSdkSetting<String>("AWS_EXECUTION_ENV", "aws.executionEnvironment")
 }

--- a/aws-runtime/protocols/http/common/src/aws/sdk/kotlin/runtime/http/AwsUserAgentMetadata.kt
+++ b/aws-runtime/protocols/http/common/src/aws/sdk/kotlin/runtime/http/AwsUserAgentMetadata.kt
@@ -5,6 +5,7 @@
 
 package aws.sdk.kotlin.runtime.http
 
+import aws.sdk.kotlin.runtime.AwsSdkSetting
 import aws.smithy.kotlin.runtime.util.OsFamily
 import aws.smithy.kotlin.runtime.util.Platform
 
@@ -133,8 +134,8 @@ public data class ExecutionEnvMetadata(val name: String) {
 }
 
 private fun detectExecEnv(): ExecutionEnvMetadata? =
-    Platform.getenv("AWS_LAMBDA_FUNCTION_NAME")?.let {
-        ExecutionEnvMetadata("lambda")
+    Platform.getenv(AwsSdkSetting.AwsExecutionEnv.environmentVariable)?.let {
+        ExecutionEnvMetadata(it)
     }
 
 // ua-value = token


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
fixes #181 

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Read `AWS_EXECUTION_ENV` instead of manually setting a hard coded value.

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
