### PR TITLE
Fix missed conversion from ULong to Long in polly presigner.  

### DIFF
--- a/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/customization/polly/PollyPresigner.kt
+++ b/codegen/smithy-aws-kotlin-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/customization/polly/PollyPresigner.kt
@@ -44,7 +44,7 @@ class PollyPresigner : KotlinIntegration {
         writer.addImport(RuntimeTypes.Http.HttpMethod)
         writer.write(
             """            
-            require(durationSeconds > 0u) { "duration must be greater than zero" }
+            require(durationSeconds > 0) { "duration must be greater than zero" }
             val httpRequestBuilder = SynthesizeSpeechOperationSerializer().serialize(ExecutionContext.build { }, input)
             val queryStringBuilder = QueryParametersBuilder()
             """.trimIndent()


### PR DESCRIPTION
Related to https://github.com/awslabs/aws-sdk-kotlin/pull/359

<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-kotlin/issues/354

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
* Fix Polly specific codegen which gens a ULong

## Scope
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
