### PR TITLE
chore: remove unused crtKotlinVersion from gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,9 +27,6 @@ atomicFuVersion=0.17.1
 kotlinxSerializationVersion=1.3.2
 ktorVersion=1.6.8
 
-# crt
-crtKotlinVersion=0.5.4
-
 # testing/utility
 junitVersion=5.8.2
 ktlintVersion=0.45.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Remove unused gradle property to avoid confusion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
