### PR TITLE
misc: run release readiness check when labled and more

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -5,6 +5,7 @@ description: >
 
 on:
   pull_request:
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
-

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Currently the workflow doesn't run again when the `ready-for-release` label is added. This makes it run when a label is added, removed, and more. Removing the need to re-run the workflow manually after adding the label

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
