### PR TITLE
chore: parallize all builds by default

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -124,7 +124,7 @@ jobs:
         run: |
           # protocol tests require everything is published
           pwd
-          ./gradlew --parallel assemble 
+          ./gradlew assemble
           ./gradlew publishToMavenLocal
       - name: Configure Gradle aws-sdk-kotlin
         uses: aws/aws-kotlin-repo-tools/.github/actions/configure-gradle@main

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ kotlin.native.ignoreDisabledTargets=true
 
 # gradle
 org.gradle.jvmargs=-Xmx10g -XX:MaxMetaspaceSize=2G
+org.gradle.parallel=true
 
 # sdk
 sdkVersion=1.5.60-SNAPSHOT


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Parallelize all builds by default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
