### PR TITLE
fix: bump to latest smithy-kotlin version for codegen fixes

### DIFF
--- a/.changes/d0acb5d7-6b4e-4163-92d0-444b89455052.json
+++ b/.changes/d0acb5d7-6b4e-4163-92d0-444b89455052.json
@@ -1,0 +1,8 @@
+{
+    "id": "d0acb5d7-6b4e-4163-92d0-444b89455052",
+    "type": "bugfix",
+    "description": "Bump **smithy-kotlin** to **v1.5.15** to pick up fixes for codegen member/package collision",
+    "issues": [
+        "smithy-lang/smithy-kotlin#1444"
+    ]
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,8 +12,8 @@ atomicfu-version = "0.29.0"
 binary-compatibility-validator-version = "0.18.0"
 
 # smithy-kotlin codegen and runtime are versioned separately
-smithy-kotlin-runtime-version = "1.5.12"
-smithy-kotlin-codegen-version = "0.35.12"
+smithy-kotlin-runtime-version = "1.5.15"
+smithy-kotlin-codegen-version = "0.35.15"
 
 # codegen
 smithy-version = "1.62.0"


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Bump **smithy-kotlin** version to pick up [smithy-kotlin#1444](https://github.com/smithy-lang/smithy-kotlin/pull/1444)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
