### PR TITLE
fix: workflow concurrency groups

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
           fi
 
 concurrency:
-  group: ${{ github.ref }}
+  group: e2e-tests-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -43,7 +43,7 @@ jobs:
           fi
 
 concurrency:
-  group: ${{ github.ref }}
+  group: service-ci-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Two different workflows were sharing the same concurrency group. Meaning only one of them could run at a time when they both should be able to run concurrently.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
