### PR TITLE
fix: bump `maxHeapSize` for Dokka generation

### DIFF
--- a/buildSrc/src/main/kotlin/dokka-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/dokka-convention.gradle.kts
@@ -14,7 +14,7 @@ dokka {
     moduleVersion.set(sdkVersion)
 
     dokkaGeneratorIsolation = ProcessIsolation {
-        maxHeapSize = "4g"
+        maxHeapSize = "16g"
     }
 
     pluginsConfiguration.html {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
