### PR TITLE
feat: upgrade smithy-kotlin to pick up latest CRT changes

### DIFF
--- a/.changes/ad8d54e2-4cd7-4fd8-8657-408df2cef264.json
+++ b/.changes/ad8d54e2-4cd7-4fd8-8657-408df2cef264.json
@@ -1,0 +1,5 @@
+{
+    "id": "ad8d54e2-4cd7-4fd8-8657-408df2cef264",
+    "type": "feature",
+    "description": "Upgrade **smithy-kotlin** to [**v1.5.19**](https://github.com/smithy-lang/smithy-kotlin/releases/tag/v1.5.19) containing a new CRT cipher suite"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,8 +12,8 @@ atomicfu-version = "0.29.0"
 binary-compatibility-validator-version = "0.18.0"
 
 # smithy-kotlin codegen and runtime are versioned separately
-smithy-kotlin-runtime-version = "1.5.17"
-smithy-kotlin-codegen-version = "0.35.17"
+smithy-kotlin-runtime-version = "1.5.19"
+smithy-kotlin-codegen-version = "0.35.19"
 
 # codegen
 smithy-version = "1.62.0"


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Bumps the **smithy-kotlin** version to [**v1.5.19**](https://github.com/smithy-lang/smithy-kotlin/releases/tag/v1.5.19) to pick up the latest version of CRT including support for a new cipher suite.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
