### PR TITLE
chore: remove `@ExperimentalApi` annotations from DDB Mapper APIs

### DIFF
--- a/hll/build.gradle.kts
+++ b/hll/build.gradle.kts
@@ -27,7 +27,6 @@ val sdkVersion: String by project
 val libraries = libs
 
 val optinAnnotations = listOf(
-    "aws.smithy.kotlin.runtime.ExperimentalApi",
     "aws.smithy.kotlin.runtime.InternalApi",
     "aws.sdk.kotlin.runtime.InternalSdkApi",
     "kotlin.RequiresOptIn",

--- a/hll/dynamodb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/rendering/DataTypeGenerator.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/rendering/DataTypeGenerator.kt
@@ -5,8 +5,14 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.codegen.operations.rendering
 
 import aws.sdk.kotlin.hll.codegen.core.CodeGenerator
-import aws.sdk.kotlin.hll.codegen.model.*
-import aws.sdk.kotlin.hll.codegen.rendering.*
+import aws.sdk.kotlin.hll.codegen.model.Member
+import aws.sdk.kotlin.hll.codegen.model.Structure
+import aws.sdk.kotlin.hll.codegen.model.asParamsList
+import aws.sdk.kotlin.hll.codegen.model.genericVars
+import aws.sdk.kotlin.hll.codegen.rendering.BuilderRenderer
+import aws.sdk.kotlin.hll.codegen.rendering.RenderContext
+import aws.sdk.kotlin.hll.codegen.rendering.RenderOptions
+import aws.sdk.kotlin.hll.codegen.rendering.Visibility
 import aws.sdk.kotlin.hll.codegen.util.plus
 
 /**
@@ -60,9 +66,7 @@ internal class DataTypeGenerator(
     private val structure: Structure,
 ) : CodeGenerator by generator {
     fun generate() {
-        write("@#T", Types.Smithy.ExperimentalApi)
         withBlock("public interface #T {", "}", structure.type) {
-            write("@#T", Types.Smithy.ExperimentalApi)
             write("public companion object { }") // leave room for future expansion
             blankLine()
             members { write("public val #L: #T", name, type) }
@@ -85,7 +89,6 @@ internal class DataTypeGenerator(
         BuilderRenderer(this, structure.type, implType, structure.members, builderCtx).render()
 
         blankLine()
-        write("@#T", Types.Smithy.ExperimentalApi)
         withBlock(
             "public fun #1L#2T.toBuilder(): #3L#4L = #3L#4L().apply {",
             "}",
@@ -98,7 +101,6 @@ internal class DataTypeGenerator(
         }
 
         blankLine()
-        write("@#T", Types.Smithy.ExperimentalApi)
         withBlock(
             "public fun #1L#2T.copy(block: #3L#4L.() -> Unit): #2T =",
             "",
@@ -111,7 +113,6 @@ internal class DataTypeGenerator(
         }
 
         blankLine()
-        write("@#T", Types.Smithy.ExperimentalApi)
         withBlock(
             "public fun #L#L(block: #L#L.() -> Unit): #T =",
             "",

--- a/hll/dynamodb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/rendering/OperationsTypeRenderer.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/rendering/OperationsTypeRenderer.kt
@@ -105,7 +105,6 @@ internal class OperationsTypeRenderer(
             write("operations after mapping objects to items and vice versa")
             write("@param T The type of objects which will be read from and/or written to this #L", entityName)
         }
-        write("@#T", Types.Smithy.ExperimentalApi)
         writeInline("public interface #T ", interfaceType)
 
         parentType?.let { writeInline(": #T ", parentType) }

--- a/hll/dynamodb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/rendering/PaginatorRenderer.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper-ops-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/operations/rendering/PaginatorRenderer.kt
@@ -112,7 +112,6 @@ internal class PaginatorRenderer(
 
     private fun renderItemsPaginator() {
         val jvmName = "${op.methodName}${paginationInfo.items.name.capitalizeFirstChar}"
-        write("@#T", Types.Smithy.ExperimentalApi)
         write("@#T(#S)", Types.Kotlin.Jvm.JvmName, jvmName)
         withBlock("public fun <T> #T.items(): #T =", "", pageFlowType, itemFlowType) {
             withBlock("#T { page ->", "}", Types.Kotlinx.Coroutines.Flow.transform) {
@@ -124,7 +123,6 @@ internal class PaginatorRenderer(
     }
 
     private fun renderPaginatorWithDsl() {
-        write("@#T", Types.Smithy.ExperimentalApi)
         writeInline("public inline fun <T> ")
 
         extensionOf?.let { writeInline("#T.", extensionOf) }
@@ -141,7 +139,6 @@ internal class PaginatorRenderer(
     }
 
     private fun renderPaginatorWithRequest() {
-        write("@#T", Types.Smithy.ExperimentalApi)
         writeInline("public fun <T> ")
 
         extensionOf?.let { writeInline("#T.", extensionOf) }

--- a/hll/dynamodb-mapper/dynamodb-mapper-schema-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/annotations/rendering/SchemaRenderer.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper-schema-codegen/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/codegen/annotations/rendering/SchemaRenderer.kt
@@ -111,7 +111,6 @@ internal class SchemaRenderer(
     }
 
     private fun renderItemConverter() {
-        write("@#T", Types.Smithy.ExperimentalApi)
         withBlock("#Lobject #L : #T by #T(", ")", ctx.attributes.visibility, converterName, MapperTypes.Items.itemConverter(classType), MapperTypes.Items.SimpleItemConverter) {
             if (shouldRenderBuilder) {
                 write("builderFactory = ::#L,", builderName)
@@ -136,7 +135,6 @@ internal class SchemaRenderer(
      */
     private fun renderValueConverter() {
         // TODO Offer alternate serialization options besides AttributeValue.M?
-        write("@#T", Types.Smithy.ExperimentalApi)
         write(
             "#Lval #L : #T = #T.#T(#T)",
             ctx.attributes.visibility,
@@ -291,7 +289,6 @@ internal class SchemaRenderer(
             MapperTypes.Items.itemSchemaPartitionKey(classType, partitionKeyProp.typeRef)
         }
 
-        write("@#T", Types.Smithy.ExperimentalApi)
         withBlock("#Lobject #L : #T {", "}", ctx.attributes.visibility, schemaName, schemaType) {
             write("override val converter: #1T = #1T", itemConverter)
             write("override val partitionKey: #T = #T(#S)", MapperTypes.Items.keySpec(partitionKeyProp.keySpec), partitionKeyProp.keySpecType, partitionKeyName)
@@ -322,7 +319,6 @@ internal class SchemaRenderer(
         docs("Returns a reference to a table named [name] containing items representing [#T]", classType)
 
         val fnName = "get${className}Table"
-        write("@#T", Types.Smithy.ExperimentalApi)
         write(
             "#Lfun #T.#L(name: String): #T = #L(name, #L)",
             ctx.attributes.visibility,

--- a/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/plugins/SchemaGeneratorPlugin.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/plugins/SchemaGeneratorPlugin.kt
@@ -6,14 +6,12 @@ package aws.sdk.kotlin.hll.dynamodbmapper.plugins
 
 import aws.sdk.kotlin.hll.codegen.rendering.RenderOptions
 import aws.sdk.kotlin.hll.dynamodbmapper.codegen.annotations.AnnotationsProcessorOptions
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import com.google.devtools.ksp.gradle.KspExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.create
 
-@ExperimentalApi
 public class SchemaGeneratorPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
         val extension = createExtension()

--- a/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/plugins/SchemaGeneratorPluginExtension.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/main/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/plugins/SchemaGeneratorPluginExtension.kt
@@ -8,11 +8,9 @@ package aws.sdk.kotlin.hll.dynamodbmapper.plugins
 import aws.sdk.kotlin.hll.codegen.rendering.Visibility
 import aws.sdk.kotlin.hll.dynamodbmapper.codegen.annotations.DestinationPackage
 import aws.sdk.kotlin.hll.dynamodbmapper.codegen.annotations.GenerateBuilderClasses
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 internal const val SCHEMA_GENERATOR_PLUGIN_EXTENSION = "dynamoDbMapper"
 
-@ExperimentalApi
 public open class SchemaGeneratorPluginExtension {
     /**
      * Determines when a builder class should be generated for user classes. Defaults to "WHEN_REQUIRED".

--- a/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/plugins/SchemaGeneratorPluginTest.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/kotlin/aws/sdk/kotlin/hll/dynamodbmapper/plugins/SchemaGeneratorPluginTest.kt
@@ -207,9 +207,7 @@ class SchemaGeneratorPluginTest {
     fun testGenerateBuilderOption() {
         val pluginConfiguration = """
         import aws.sdk.kotlin.hll.dynamodbmapper.codegen.annotations.GenerateBuilderClasses
-        import aws.smithy.kotlin.runtime.ExperimentalApi
         
-        @OptIn(ExperimentalApi::class)
         dynamoDbMapper {
             generateBuilderClasses = GenerateBuilderClasses.ALWAYS
         }
@@ -240,9 +238,7 @@ class SchemaGeneratorPluginTest {
     fun testVisibilityOption() {
         val pluginConfiguration = """
         import aws.sdk.kotlin.hll.codegen.rendering.Visibility
-        import aws.smithy.kotlin.runtime.ExperimentalApi
         
-        @OptIn(ExperimentalApi::class)
         dynamoDbMapper {
             visibility = Visibility.INTERNAL
         }
@@ -270,9 +266,6 @@ class SchemaGeneratorPluginTest {
     @Test
     fun testGenerateGetTableFunctionOption() {
         val pluginConfiguration = """
-        import aws.smithy.kotlin.runtime.ExperimentalApi
-        
-        @OptIn(ExperimentalApi::class)
         dynamoDbMapper {
             generateGetTableExtension = false
         }
@@ -301,9 +294,7 @@ class SchemaGeneratorPluginTest {
     fun testRelativeDestinationPackage() {
         val pluginConfiguration = """
         import aws.sdk.kotlin.hll.dynamodbmapper.codegen.annotations.DestinationPackage
-        import aws.smithy.kotlin.runtime.ExperimentalApi
         
-        @OptIn(ExperimentalApi::class)
         dynamoDbMapper {
             destinationPackage = DestinationPackage.Relative("hello.moto")
         }
@@ -328,9 +319,7 @@ class SchemaGeneratorPluginTest {
     fun testAbsoluteDestinationPackage() {
         val pluginConfiguration = """
         import aws.sdk.kotlin.hll.dynamodbmapper.codegen.annotations.DestinationPackage
-        import aws.smithy.kotlin.runtime.ExperimentalApi
         
-        @OptIn(ExperimentalApi::class)
         dynamoDbMapper {
             destinationPackage = DestinationPackage.Absolute("absolutely.my.`package`")
         }

--- a/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/custom-item-converter/CustomItemConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/custom-item-converter/CustomItemConverter.kt
@@ -10,10 +10,8 @@ import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemConverter
 import aws.sdk.kotlin.hll.dynamodbmapper.items.SimpleItemConverter
 import aws.sdk.kotlin.hll.dynamodbmapper.values.scalars.NumberValueConverters
 import aws.sdk.kotlin.hll.dynamodbmapper.values.scalars.StringValueConverter
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import org.example.CustomUser
 
-@OptIn(ExperimentalApi::class)
 public object MyCustomUserConverter : ItemConverter<CustomUser> by SimpleItemConverter(
     builderFactory = { CustomUser() },
     build = { this },

--- a/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/standard-item-converters/test/ListsTest.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/standard-item-converters/test/ListsTest.kt
@@ -4,12 +4,10 @@
  */
 package org.example
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import org.example.dynamodbmapper.generatedschemas.ListsConverter
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalApi::class)
 public class ListsTest {
     @Test
     fun converterTest() {

--- a/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/standard-item-converters/test/MapsTest.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/standard-item-converters/test/MapsTest.kt
@@ -4,12 +4,10 @@
  */
 package org.example
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import org.example.dynamodbmapper.generatedschemas.MapsConverter
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalApi::class)
 public class MapsTest {
     @Test
     fun converterTest() {

--- a/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/standard-item-converters/test/NullableItemTest.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/standard-item-converters/test/NullableItemTest.kt
@@ -4,13 +4,11 @@
  */
 package org.example
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.time.Instant
 import org.example.dynamodbmapper.generatedschemas.NullableItemConverter
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalApi::class)
 public class NullableItemTest {
     @Test
     fun converterTest() {

--- a/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/standard-item-converters/test/PrimitivesTest.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/standard-item-converters/test/PrimitivesTest.kt
@@ -4,7 +4,6 @@
  */
 package org.example
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.content.Document
 import aws.smithy.kotlin.runtime.net.url.Url
 import aws.smithy.kotlin.runtime.time.Instant
@@ -12,7 +11,6 @@ import org.example.dynamodbmapper.generatedschemas.PrimitivesConverter
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalApi::class)
 public class PrimitivesTest {
     @Test
     fun converterTest() {

--- a/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/standard-item-converters/test/SetsTest.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/standard-item-converters/test/SetsTest.kt
@@ -4,12 +4,10 @@
  */
 package org.example
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import org.example.dynamodbmapper.generatedschemas.SetsConverter
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalApi::class)
 public class SetsTest {
     @Test
     fun converterTest() {

--- a/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/tests/UserTest.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper-schema-generator-plugin/src/test/resources/tests/UserTest.kt
@@ -6,12 +6,10 @@ package org.example
 
 import aws.sdk.kotlin.hll.dynamodbmapper.model.itemOf
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import org.example.dynamodbmapper.generatedschemas.UserConverter
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalApi::class)
 class UserTest {
     @Test
     fun testConversion() {

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/DynamoDbMapper.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/DynamoDbMapper.kt
@@ -4,6 +4,8 @@
  */
 package aws.sdk.kotlin.hll.dynamodbmapper
 
+import aws.sdk.kotlin.hll.dynamodbmapper.DynamoDbMapper.Companion.Config
+import aws.sdk.kotlin.hll.dynamodbmapper.DynamoDbMapper.Config.Companion.Builder
 import aws.sdk.kotlin.hll.dynamodbmapper.internal.DynamoDbMapperImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.internal.MapperConfigBuilderImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
@@ -11,14 +13,11 @@ import aws.sdk.kotlin.hll.dynamodbmapper.model.Table
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.Interceptor
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.InterceptorAny
 import aws.sdk.kotlin.services.dynamodb.DynamoDbClient
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * A high-level client for DynamoDB which maps custom data types into DynamoDB attributes and vice versa.
  */
-@ExperimentalApi
 public interface DynamoDbMapper {
-    @ExperimentalApi
     public companion object {
         /**
          * Instantiate a new [Config] object
@@ -112,7 +111,6 @@ public interface DynamoDbMapper {
  * @param client The low-level DynamoDB client to use for underlying calls to the service
  * @param config A DSL configuration block
  */
-@ExperimentalApi
 public fun DynamoDbMapper(
     client: DynamoDbClient,
     config: DynamoDbMapper.Config.Builder.() -> Unit = { },

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/annotations/ManualPagination.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/annotations/ManualPagination.kt
@@ -4,12 +4,9 @@
  */
 package aws.sdk.kotlin.hll.dynamodbmapper.annotations
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
-
 /**
  * Indicates that an operation invocation method (e.g., `query`) does not provide automatic pagination. While desirable
  * in advanced scenarios, the typical use case should favor the paginated equivalent (e.g., `queryPaginated`).
  */
-@ExperimentalApi
 @RequiresOptIn(message = "This method does not provide automatic pagination over results and should only be used in advanced scenarios. Where possible, consider using the paginated equivalent. To explicitly opt into using this method, annotate the call site with `@OptIn(ManualPagination::class)`.")
 public annotation class ManualPagination(val paginatedEquivalent: String)

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/AndExpr.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/AndExpr.kt
@@ -5,14 +5,12 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.AndExprImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Represents an `AND` expression as described in
  * [DynamoDB's **logical evaluations** documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.LogicalEvaluations).
  * This expression will be true if `(operand[0] && operand[1] && ... && operand[n - 1])`.
  */
-@ExperimentalApi
 public interface AndExpr : BooleanExpr {
     /**
      * A list of 2 or more [BooleanExpr] conditions which are ANDed together
@@ -26,5 +24,4 @@ public interface AndExpr : BooleanExpr {
  * Creates a new [AndExpr] with the given [operands]
  * @param operands A list of 2 or more [BooleanExpr] conditions which are ANDed together
  */
-@ExperimentalApi
 public fun AndExpr(operands: List<BooleanExpr>): AndExpr = AndExprImpl(operands)

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/AttributePath.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/AttributePath.kt
@@ -7,17 +7,14 @@ package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.AttrPathIndexImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.AttrPathNameImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.AttributePathImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Represents an element in an [AttributePath]
  */
-@ExperimentalApi
 public sealed interface AttrPathElement {
     /**
      * Represents the name of a top-level attribute or a key in a map
      */
-    @ExperimentalApi
     public interface Name : AttrPathElement {
         /**
          * The name or key of this element
@@ -28,7 +25,6 @@ public sealed interface AttrPathElement {
     /**
      * Represents an index into a list/set
      */
-    @ExperimentalApi
     public interface Index : AttrPathElement {
         /**
          * The index (starting at `0`)
@@ -46,7 +42,6 @@ public sealed interface AttrPathElement {
  *
  * See [Filter] for more information about creating references to attributes.
  */
-@ExperimentalApi
 public interface AttributePath : Expression {
     /**
      * The [AttrPathElement] for this path
@@ -68,7 +63,6 @@ public interface AttributePath : Expression {
  * @param parent The parent [AttributePath] (if any) of this element. If [parent] is `null` then this instance
  * represents a top-level attribute.
  */
-@ExperimentalApi
 public fun AttributePath(name: String, parent: AttributePath? = null): AttributePath =
     AttributePathImpl(AttrPathNameImpl(name), parent)
 
@@ -77,6 +71,5 @@ public fun AttributePath(name: String, parent: AttributePath? = null): Attribute
  * @param index The index (starting at `0`) of this element
  * @param parent The parent [AttributePath] of this element
  */
-@ExperimentalApi
 public fun AttributePath(index: Int, parent: AttributePath): AttributePath =
     AttributePathImpl(AttrPathIndexImpl(index), parent)

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/AttributeType.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/AttributeType.kt
@@ -4,14 +4,11 @@
  */
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
-
 /**
  * Represents a
  * [DynamoDB attribute data type](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
  * @param abbreviation The DynamoDB type name
  */
-@ExperimentalApi
 public enum class AttributeType(public val abbreviation: kotlin.String) {
     /**
      * Binary data type, denoted in DynamoDB as `B`

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/BetweenExpr.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/BetweenExpr.kt
@@ -5,14 +5,12 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.BetweenExprImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Represents a `BETWEEN` expression as described in
  * [DynamoDB's **making comparisons** documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Comparators).
  * This expression will be true if `value >= min && value <= max`.
  */
-@ExperimentalApi
 public interface BetweenExpr :
     BooleanExpr,
     SortKeyExpr {
@@ -40,6 +38,5 @@ public interface BetweenExpr :
  * @param min The minimum bound for the comparison
  * @param max The maximum bound for the comparison
  */
-@ExperimentalApi
 public fun BetweenExpr(value: Expression, min: Expression, max: Expression): BetweenExpr =
     BetweenExprImpl(value, min, max)

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanFunc.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanFunc.kt
@@ -4,15 +4,12 @@
  */
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
-
 /**
  * Identifies a
  * [DynamoDB expression function](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Functions)
  * which returns a boolean value
  * @param exprString The literal name of the function to use in expression strings
  */
-@ExperimentalApi
 public enum class BooleanFunc(public val exprString: String) {
     /**
      * The `attribute_exist` function

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanFuncExpr.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/BooleanFuncExpr.kt
@@ -5,13 +5,11 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.BooleanFuncExprImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Represents a function expression that yields a boolean result as described in
  * [DynamoDB's **function** documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Functions)
  */
-@ExperimentalApi
 public interface BooleanFuncExpr :
     BooleanExpr,
     SortKeyExpr {
@@ -39,7 +37,6 @@ public interface BooleanFuncExpr :
  * @param path The attribute path to pass as the function's first argument
  * @param additionalOperands Any additional arguments used by the function
  */
-@ExperimentalApi
 public fun BooleanFuncExpr(
     func: BooleanFunc,
     path: AttributePath,
@@ -52,7 +49,6 @@ public fun BooleanFuncExpr(
  * @param path The attribute path to pass as the function's first argument
  * @param additionalOperands Any additional arguments used by the function
  */
-@ExperimentalApi
 public fun BooleanFuncExpr(
     func: BooleanFunc,
     path: AttributePath,

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/Comparator.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/Comparator.kt
@@ -4,13 +4,10 @@
  */
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
-
 /**
  * Identifies a comparison operator to use in an expression
  * @param exprString The literal value of the operator to use in an expression string
  */
-@ExperimentalApi
 public enum class Comparator(public val exprString: String) {
     /**
      * An equality comparison, equivalent to `==` in Kotlin and to `=` in DynamoDB

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/ComparisonExpr.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/ComparisonExpr.kt
@@ -5,14 +5,12 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.ComparisonExprImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Represents a comparison expression as described in
  * [DynamoDB's **making comparisons** documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Comparators).
  * The specific type of comparison is identified by the [comparator] field.
  */
-@ExperimentalApi
 public interface ComparisonExpr :
     BooleanExpr,
     SortKeyExpr {
@@ -40,6 +38,5 @@ public interface ComparisonExpr :
  * @param left The left value being compared
  * @param right The right value being compared
  */
-@ExperimentalApi
 public fun ComparisonExpr(comparator: Comparator, left: Expression, right: Expression): ComparisonExpr =
     ComparisonExprImpl(comparator, left, right)

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/ExpressionVisitor.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/ExpressionVisitor.kt
@@ -4,13 +4,10 @@
  */
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
-
 /**
  * A [visitor](https://en.wikipedia.org/wiki/Visitor_pattern) that can traverse an [Expression]
  * @param T The type of value used for state tracking by this visitor
  */
-@ExperimentalApi
 public interface ExpressionVisitor<T> {
     /**
      * Visit an [AndExpr]

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/Expressions.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/Expressions.kt
@@ -4,8 +4,6 @@
  */
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
-
 /**
  * Represents any kind of expression. This is an abstract top-level interface and describes no details about an
  * expression on its own. Expressions may be of various specific types (e.g., [AttributePath], [ComparisonExpr],
@@ -14,7 +12,6 @@ import aws.smithy.kotlin.runtime.ExperimentalApi
  * [Expression] and its derivatives support the [visitor design pattern](https://en.wikipedia.org/wiki/Visitor_pattern)
  * by way of an [accept] method.
  */
-@ExperimentalApi
 public sealed interface Expression {
     /**
      * Accepts a visitor that is traversing an expression tree by dispatching to a subtype implementation. Subtype
@@ -30,7 +27,6 @@ public sealed interface Expression {
  * items. This is a [marker interface](https://en.wikipedia.org/wiki/Marker_interface_pattern) which adds no additional
  * declarations.
  */
-@ExperimentalApi
 public sealed interface BooleanExpr : Expression
 
 /**
@@ -38,5 +34,4 @@ public sealed interface BooleanExpr : Expression
  * key. This is a [marker interface](https://en.wikipedia.org/wiki/Marker_interface_pattern) which adds no additional
  * declarations.
  */
-@ExperimentalApi
 public sealed interface SortKeyExpr : Expression

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/Filter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/Filter.kt
@@ -5,8 +5,6 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
 import aws.sdk.kotlin.hll.dynamodbmapper.util.dynamicAttr
-import aws.smithy.kotlin.runtime.ExperimentalApi
-import kotlin.jvm.JvmName
 
 /**
  * A DSL interface providing support for "low-level" filter expressions. Implementations of this interface provide
@@ -181,7 +179,6 @@ import kotlin.jvm.JvmName
  * attr("bar").exists()    // Checks whether any value exists for `bar` (including `null`)
  * ```
  */
-@ExperimentalApi
 public interface Filter {
     // ATTRIBUTES
 

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/InExpr.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/InExpr.kt
@@ -5,14 +5,12 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.InExprImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Represents an `IN` expression as described in
  * [DynamoDB's **making comparisons** documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Comparators).
  * This expression will be true if `value in set` (or, equivalently, if `set.contains(value)`).
  */
-@ExperimentalApi
 public interface InExpr : BooleanExpr {
     /**
      * The value to check for in [set]
@@ -32,5 +30,4 @@ public interface InExpr : BooleanExpr {
  * @param value The value to check for in [set]
  * @param set The set of values to compare against [value]
  */
-@ExperimentalApi
 public fun InExpr(value: Expression, set: Collection<Expression>): InExpr = InExprImpl(value, set)

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/KeyFilter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/KeyFilter.kt
@@ -6,13 +6,11 @@ package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.KeyFilterImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.SortKeyFilterImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Represents a filter which limits a Query operation to a specific partition key and optional sort key criteria (if
  * applicable)
  */
-@ExperimentalApi
 public interface KeyFilter {
     /**
      * The required value of the partition key
@@ -30,7 +28,6 @@ public interface KeyFilter {
  * @param partitionKey The value required for the partition key. This must be set to a byte array, string, or number
  * (including unsigned numbers).
  */
-@ExperimentalApi
 public fun KeyFilter(partitionKey: Any): KeyFilter = KeyFilterImpl(partitionKey, null)
 
 /**
@@ -40,6 +37,5 @@ public fun KeyFilter(partitionKey: Any): KeyFilter = KeyFilterImpl(partitionKey,
  * (including unsigned numbers).
  * @param sortKey A DSL block that sets the condition for the sort key. See [SortKeyFilter] for more details.
  */
-@ExperimentalApi
 public fun KeyFilter(partitionKey: Any, sortKey: SortKeyFilter.() -> SortKeyExpr): KeyFilter =
     KeyFilterImpl(partitionKey, SortKeyFilterImpl.run(sortKey))

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/LiteralExpr.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/LiteralExpr.kt
@@ -7,13 +7,10 @@ package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.LiteralExprImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.util.attr
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
-import kotlin.jvm.JvmName
 
 /**
  * Represents an expression that consists of a single literal value
  */
-@ExperimentalApi
 public interface LiteralExpr : Expression {
     /**
      * The low-level DynamoDB representation of the literal value
@@ -27,7 +24,6 @@ public interface LiteralExpr : Expression {
  * Creates a new literal expression
  * @param value The low-level DynamoDB representation of the literal value
  */
-@ExperimentalApi
 public fun LiteralExpr(value: AttributeValue): LiteralExpr = LiteralExprImpl(value)
 
 private val NULL_LITERAL = LiteralExpr(attr(null))
@@ -36,35 +32,30 @@ private val NULL_LITERAL = LiteralExpr(attr(null))
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 public fun LiteralExpr(value: Boolean?): LiteralExpr = LiteralExpr(attr(value))
 
 /**
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 public fun LiteralExpr(value: ByteArray?): LiteralExpr = LiteralExpr(attr(value))
 
 /**
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 public fun LiteralExpr(value: List<Any?>?): LiteralExpr = LiteralExpr(attr(value))
 
 /**
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 public fun LiteralExpr(value: Map<String, Any?>?): LiteralExpr = LiteralExpr(attr(value))
 
 /**
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 @Suppress("UNUSED_PARAMETER")
 public fun LiteralExpr(value: Nothing?): LiteralExpr = NULL_LITERAL
 
@@ -72,14 +63,12 @@ public fun LiteralExpr(value: Nothing?): LiteralExpr = NULL_LITERAL
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 public fun LiteralExpr(value: Number?): LiteralExpr = LiteralExpr(attr(value))
 
 /**
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 @JvmName("LiteralExprSetByteArray")
 public fun LiteralExpr(value: Set<ByteArray>?): LiteralExpr = LiteralExpr(attr(value))
 
@@ -87,7 +76,6 @@ public fun LiteralExpr(value: Set<ByteArray>?): LiteralExpr = LiteralExpr(attr(v
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 @JvmName("LiteralExprSetNumber")
 public fun LiteralExpr(value: Set<Number>?): LiteralExpr = LiteralExpr(attr(value))
 
@@ -95,7 +83,6 @@ public fun LiteralExpr(value: Set<Number>?): LiteralExpr = LiteralExpr(attr(valu
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 @JvmName("LiteralExprSetString")
 public fun LiteralExpr(value: Set<String>?): LiteralExpr = LiteralExpr(attr(value))
 
@@ -103,7 +90,6 @@ public fun LiteralExpr(value: Set<String>?): LiteralExpr = LiteralExpr(attr(valu
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 @JvmName("LiteralExprSetUByte")
 public fun LiteralExpr(value: Set<UByte>?): LiteralExpr = LiteralExpr(attr(value))
 
@@ -111,7 +97,6 @@ public fun LiteralExpr(value: Set<UByte>?): LiteralExpr = LiteralExpr(attr(value
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 @JvmName("LiteralExprSetUInt")
 public fun LiteralExpr(value: Set<UInt>?): LiteralExpr = LiteralExpr(attr(value))
 
@@ -119,7 +104,6 @@ public fun LiteralExpr(value: Set<UInt>?): LiteralExpr = LiteralExpr(attr(value)
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 @JvmName("LiteralExprSetULong")
 public fun LiteralExpr(value: Set<ULong>?): LiteralExpr = LiteralExpr(attr(value))
 
@@ -127,7 +111,6 @@ public fun LiteralExpr(value: Set<ULong>?): LiteralExpr = LiteralExpr(attr(value
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 @JvmName("LiteralExprSetUShort")
 public fun LiteralExpr(value: Set<UShort>?): LiteralExpr = LiteralExpr(attr(value))
 
@@ -135,33 +118,28 @@ public fun LiteralExpr(value: Set<UShort>?): LiteralExpr = LiteralExpr(attr(valu
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 public fun LiteralExpr(value: String?): LiteralExpr = LiteralExpr(attr(value))
 
 /**
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 public fun LiteralExpr(value: UByte?): LiteralExpr = LiteralExpr(attr(value))
 
 /**
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 public fun LiteralExpr(value: UInt?): LiteralExpr = LiteralExpr(attr(value))
 
 /**
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 public fun LiteralExpr(value: ULong?): LiteralExpr = LiteralExpr(attr(value))
 
 /**
  * Creates a new literal expression
  * @param value The literal value which will be converted to an [AttributeValue]
  */
-@ExperimentalApi
 public fun LiteralExpr(value: UShort?): LiteralExpr = LiteralExpr(attr(value))

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/NotExpr.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/NotExpr.kt
@@ -5,14 +5,12 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.NotExprImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Represents a `NOT` expression as described in
  * [DynamoDB's **logical evaluations** documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.LogicalEvaluations).
  * This expression will be true if `!operand` (i.e., `operand` evaluates to `false`).
  */
-@ExperimentalApi
 public interface NotExpr : BooleanExpr {
     /**
      * The condition to negate
@@ -26,5 +24,4 @@ public interface NotExpr : BooleanExpr {
  * Creates a new `NOT` expression
  * @param operand The condition to negate
  */
-@ExperimentalApi
 public fun NotExpr(operand: BooleanExpr): NotExpr = NotExprImpl(operand)

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/OrExpr.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/OrExpr.kt
@@ -5,14 +5,12 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.OrExprImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Represents an `OR` expression as described in
  * [DynamoDB's **logical evaluations** documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.LogicalEvaluations).
  * This expression will be true if `(operand[0] || operand[1] || ... || operand[n - 1])`.
  */
-@ExperimentalApi
 public interface OrExpr : BooleanExpr {
     /**
      * A list of 2 or more [BooleanExpr] conditions which are ANDed together
@@ -26,5 +24,4 @@ public interface OrExpr : BooleanExpr {
  * Creates a new [OrExpr] with the given [operands]
  * @param operands A list of 2 or more [BooleanExpr] conditions which are ORed together
  */
-@ExperimentalApi
 public fun OrExpr(operands: List<BooleanExpr>): OrExpr = OrExprImpl(operands)

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/ScalarFunc.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/ScalarFunc.kt
@@ -4,15 +4,12 @@
  */
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
-
 /**
  * Identifies a
  * [DynamoDB expression function](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Functions)
  * which returns a non-boolean value
  * @param exprString The literal name of the function to use in expression strings
  */
-@ExperimentalApi
 public enum class ScalarFunc(public val exprString: String) {
     /**
      * The `size` function

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/ScalarFuncExpr.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/ScalarFuncExpr.kt
@@ -5,13 +5,11 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
 import aws.sdk.kotlin.hll.dynamodbmapper.expressions.internal.ScalarFuncExprImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Represents a function expression that yields a non-boolean result as described in
  * [DynamoDB's **function** documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html#Expressions.OperatorsAndFunctions.Functions)
  */
-@ExperimentalApi
 public interface ScalarFuncExpr : BooleanExpr {
     /**
      * The specific non-boolean function to use
@@ -37,7 +35,6 @@ public interface ScalarFuncExpr : BooleanExpr {
  * @param path The attribute path to pass as the function's first argument
  * @param additionalOperands Any additional arguments used by the function
  */
-@ExperimentalApi
 public fun ScalarFuncExpr(
     func: ScalarFunc,
     path: AttributePath,
@@ -50,7 +47,6 @@ public fun ScalarFuncExpr(
  * @param path The attribute path to pass as the function's first argument
  * @param additionalOperands Any additional arguments used by the function
  */
-@ExperimentalApi
 public fun ScalarFuncExpr(
     func: ScalarFunc,
     path: AttributePath,

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/SortKeyFilter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/expressions/SortKeyFilter.kt
@@ -4,13 +4,9 @@
  */
 package aws.sdk.kotlin.hll.dynamodbmapper.expressions
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
-import kotlin.jvm.JvmName
-
 /**
  * Represents a sort key independent of schema
  */
-@ExperimentalApi
 public interface SortKey
 
 /**
@@ -75,7 +71,6 @@ public interface SortKey
  * sortKey startsWith "abc" // Checks whether the value of the sort key starts with `"abc"`
  * ```
  */
-@ExperimentalApi
 public interface SortKeyFilter {
     /**
      * Gets an attribute reference to the sort key

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/AttributeDescriptor.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/AttributeDescriptor.kt
@@ -6,7 +6,6 @@ package aws.sdk.kotlin.hll.dynamodbmapper.items
 
 import aws.sdk.kotlin.hll.dynamodbmapper.items.internal.AttributeDescriptorImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.values.ValueConverter
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Describes a single item attribute and how it is converted from an object of type [T] and to a build object of type
@@ -15,7 +14,6 @@ import aws.smithy.kotlin.runtime.ExperimentalApi
  * @param T The type of object from which values are extracted
  * @param B The type of builder object in which values are mutated
  */
-@ExperimentalApi
 public interface AttributeDescriptor<A, T, B> {
     /**
      * The name of the attribute
@@ -49,7 +47,6 @@ public interface AttributeDescriptor<A, T, B> {
  * @param converter A [ValueConverter] which defines how an object value is converted to an attribute value and vice
  * versa
  */
-@ExperimentalApi
 public fun <A, T, B> AttributeDescriptor(
     name: String,
     getter: (T) -> A,

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/DocumentItemConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/DocumentItemConverter.kt
@@ -10,7 +10,6 @@ import aws.sdk.kotlin.hll.dynamodbmapper.util.NULL_ATTR
 import aws.sdk.kotlin.hll.mapping.core.converters.MonoConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.reversedBy
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.InternalApi
 import aws.smithy.kotlin.runtime.content.Document
 import aws.smithy.kotlin.runtime.util.toNumber
@@ -27,7 +26,6 @@ private val itemToDoc = MonoConverter<Item, Document> {
 }
 
 // FIXME Combine with DocumentValueConverter or refactor to commonize as much code as possible
-@ExperimentalApi
 public val DocumentItemConverter: ItemConverter<Document> = docToItem reversedBy itemToDoc
 
 @OptIn(InternalApi::class)

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/HeterogeneousItemConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/HeterogeneousItemConverter.kt
@@ -8,7 +8,6 @@ import aws.sdk.kotlin.hll.dynamodbmapper.model.Item
 import aws.sdk.kotlin.hll.dynamodbmapper.model.buildItem
 import aws.sdk.kotlin.hll.mapping.core.converters.MonoConverter
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * An item converter which handles heterogeneous (i.e., incongruent) data types by way of a string discriminator
@@ -96,7 +95,6 @@ import aws.smithy.kotlin.runtime.ExperimentalApi
  * [typeMapper] function returns a type name which does not exist in this map, or if an item is read containing a type
  * attribute value which does not exist in this map, an exception will be thrown.
  */
-@ExperimentalApi
 public class HeterogeneousItemConverter<T>(
     public val typeMapper: (T) -> String,
     public val typeAttribute: String,

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/ItemConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/ItemConverter.kt
@@ -6,11 +6,9 @@ package aws.sdk.kotlin.hll.dynamodbmapper.items
 
 import aws.sdk.kotlin.hll.dynamodbmapper.model.Item
 import aws.sdk.kotlin.hll.mapping.core.converters.Converter
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Defines the logic for converting between objects and DynamoDB items
  * @param T The type of objects which will be converted
  */
-@ExperimentalApi
 public typealias ItemConverter<T> = Converter<T, Item>

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/ItemSchema.kt
@@ -6,14 +6,12 @@ package aws.sdk.kotlin.hll.dynamodbmapper.items
 
 import aws.sdk.kotlin.hll.dynamodbmapper.items.internal.ItemSchemaCompositeKeyImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.items.internal.ItemSchemaPartitionKeyImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Defines a schema for handling objects of a certain type, including an [ItemConverter] for converting between objects
  * items and a [KeySpec] for identifying primary keys.
  * @param T The type of objects described by this schema
  */
-@ExperimentalApi
 public interface ItemSchema<T> {
     /**
      * The [ItemConverter] used to convert between objects and items
@@ -30,7 +28,6 @@ public interface ItemSchema<T> {
      * @param T The type of objects described by this schema
      * @param PK The type of the partition key property, either [String], [Number], or [ByteArray]
      */
-    @ExperimentalApi
     public interface PartitionKey<T, in PK> : ItemSchema<T> {
         /**
          * The [KeySpec] for the partition key
@@ -47,7 +44,6 @@ public interface ItemSchema<T> {
      * @param PK The type of the partition key property, either [String], [Number], or [ByteArray]
      * @param SK The type of the sort key property, either [String], [Number], or [ByteArray]
      */
-    @ExperimentalApi
     public interface CompositeKey<T, PK, SK> : PartitionKey<T, PK> {
         /**
          * The [KeySpec] for the sort key
@@ -66,7 +62,6 @@ public interface ItemSchema<T> {
  * @param converter The [ItemConverter] used to convert between objects and items
  * @param partitionKey The [KeySpec] for the partition key
  */
-@ExperimentalApi
 @Suppress("FunctionName")
 public fun <T, PK> ItemSchema(converter: ItemConverter<T>, partitionKey: KeySpec<PK>): ItemSchema.PartitionKey<T, PK> =
     ItemSchemaPartitionKeyImpl(converter, partitionKey)
@@ -80,7 +75,6 @@ public fun <T, PK> ItemSchema(converter: ItemConverter<T>, partitionKey: KeySpec
  * @param partitionKey The [KeySpec] for the partition key
  * @param sortKey The [KeySpec] for the sort key
  */
-@ExperimentalApi
 @Suppress("FunctionName")
 public fun <T, PK, SK> ItemSchema(
     converter: ItemConverter<T>,
@@ -94,7 +88,6 @@ public fun <T, PK, SK> ItemSchema(
  * @param PK The type of the partition key property, either [String], [Number], or [ByteArray]
  * @param partitionKey The [KeySpec] that describes the partition key
  */
-@ExperimentalApi
 public fun <T, PK> ItemConverter<T>.withKeySpec(partitionKey: KeySpec<PK>): ItemSchema.PartitionKey<T, PK> =
     ItemSchema(this, partitionKey)
 
@@ -106,7 +99,6 @@ public fun <T, PK> ItemConverter<T>.withKeySpec(partitionKey: KeySpec<PK>): Item
  * @param partitionKey The [KeySpec] that describes the partition key
  * @param sortKey The [KeySpec] that describes the sort key
  */
-@ExperimentalApi
 public fun <T, PK, SK> ItemConverter<T>.withKeySpec(
     partitionKey: KeySpec<PK>,
     sortKey: KeySpec<SK>,

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/KeySpec.kt
@@ -5,33 +5,27 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.items
 
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Defines a specification for a single key attribute
  * @param K The type of the key property, either [kotlin.String], [kotlin.Number], or [kotlin.ByteArray]
  */
-@ExperimentalApi
 public sealed interface KeySpec<in K> {
     /**
      * A [KeySpec] for a [kotlin.ByteArray]-typed field
      */
-    @ExperimentalApi
     public interface ByteArray : KeySpec<kotlin.ByteArray>
 
     /**
      * A [KeySpec] for a [kotlin.Number]-typed field
      */
-    @ExperimentalApi
     public interface Number : KeySpec<kotlin.Number>
 
     /**
      * A [KeySpec] for a [kotlin.String]-typed field
      */
-    @ExperimentalApi
     public interface String : KeySpec<kotlin.String>
 
-    @ExperimentalApi
     public companion object {
         /**
          * Creates a new [ByteArray] key specification

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/SimpleItemConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/items/SimpleItemConverter.kt
@@ -8,7 +8,6 @@ import aws.sdk.kotlin.hll.dynamodbmapper.model.Item
 import aws.sdk.kotlin.hll.dynamodbmapper.model.buildItem
 import aws.sdk.kotlin.hll.mapping.core.converters.MonoConverter
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * An item converter which uses attribute descriptors to convert objects to items and vice versa. This converter
@@ -23,7 +22,6 @@ import aws.smithy.kotlin.runtime.ExperimentalApi
  * [T] are the same type, this may be an identity function.
  * @param descriptors A collection of [AttributeDescriptor] which describe how to construct and parse attributes
  */
-@ExperimentalApi
 public class SimpleItemConverter<T, B>(
     private val builderFactory: () -> B,
     private val build: B.() -> T,

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/Index.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/Index.kt
@@ -5,14 +5,12 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.model
 
 import aws.sdk.kotlin.hll.dynamodbmapper.operations.IndexOperations
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Represents a secondary index on a table in DynamoDB and an associated item schema. Operations on this index will
  * invoke low-level operations and map items to objects.
  * @param T The type of objects which will be read from this index
  */
-@ExperimentalApi
 public interface Index<T> :
     IndexSpec<T>,
     IndexOperations<T>,
@@ -23,7 +21,6 @@ public interface Index<T> :
      * @param T The type of objects which will be read from this index
      * @param PK The type of the partition key property, either [String], [Number], or [ByteArray]
      */
-    @ExperimentalApi
     public interface PartitionKey<T, PK> :
         Index<T>,
         PersistenceSpec.PartitionKey<T, PK>
@@ -34,7 +31,6 @@ public interface Index<T> :
      * @param PK The type of the partition key property, either [String], [Number], or [ByteArray]
      * @param SK The type of the sort key property, either [String], [Number], or [ByteArray]
      */
-    @ExperimentalApi
     public interface CompositeKey<T, PK, SK> :
         Index<T>,
         PersistenceSpec.CompositeKey<T, PK, SK>

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/IndexSpec.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/IndexSpec.kt
@@ -5,13 +5,11 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.model
 
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Specifies how items can be read from a secondary index
  * @param T The type of objects which will be read from this index
  */
-@ExperimentalApi
 public interface IndexSpec<T> : PersistenceSpec<T> {
     /**
      * The name of the table
@@ -26,7 +24,6 @@ public interface IndexSpec<T> : PersistenceSpec<T> {
     /**
      * Specifies how items can be read from a secondary index whose primary key consists of a single partition key
      */
-    @ExperimentalApi
     public interface PartitionKey<T, PK> : IndexSpec<T> {
         override val schema: ItemSchema.PartitionKey<T, PK>
     }
@@ -35,7 +32,6 @@ public interface IndexSpec<T> : PersistenceSpec<T> {
      * Specifies how items can be read from a secondary index whose primary key consists of a composite of a partition
      * key and a sort key
      */
-    @ExperimentalApi
     public interface CompositeKey<T, PK, SK> : IndexSpec<T> {
         override val schema: ItemSchema.CompositeKey<T, PK, SK>
     }

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/Item.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/Item.kt
@@ -7,14 +7,11 @@ package aws.sdk.kotlin.hll.dynamodbmapper.model
 import aws.sdk.kotlin.hll.dynamodbmapper.model.internal.ItemImpl
 import aws.sdk.kotlin.hll.dynamodbmapper.util.dynamicAttr
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
-import kotlin.jvm.JvmName
 
 /**
  * An immutable representation of a low-level item in a DynamoDB table. Items consist of attributes, each of which have
  * a string name and a value.
  */
-@ExperimentalApi
 public interface Item : Map<String, AttributeValue>
 
 /**
@@ -22,20 +19,17 @@ public interface Item : Map<String, AttributeValue>
  * of it.
  * @param block The block to apply to the [MutableItem] builder
  */
-@ExperimentalApi
 public inline fun buildItem(block: MutableItem.() -> Unit): Item =
     mutableMapOf<String, AttributeValue>().toMutableItem().apply(block).toItem()
 
 /**
  * Convert this [Item] into a [MutableItem]. Changes to the returned instance do not affect this instance.
  */
-@ExperimentalApi
 public fun Item.toMutableItem(): MutableItem = toMutableMap().toMutableItem()
 
 /**
  * Converts this map to an immutable [Item]
  */
-@ExperimentalApi
 public fun Map<String, AttributeValue>.toItem(): Item = ItemImpl(this)
 
 /**
@@ -49,7 +43,6 @@ internal fun Map<String, Any?>.toItem() = mapValues { (_, v) -> dynamicAttr(v) }
  * @param pairs A collection of [Pair]<[String], [AttributeValue]> where the first value is the attribute name and the
  * second is the attribute value.
  */
-@ExperimentalApi
 public fun itemOf(vararg pairs: Pair<String, AttributeValue>): Item = mapOf(*pairs).toItem()
 
 /**

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/ItemSource.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/ItemSource.kt
@@ -5,12 +5,10 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.model
 
 import aws.sdk.kotlin.hll.dynamodbmapper.operations.ItemSourceOperations
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Represents a source of DynamoDB items (such as a table or secondary index)
  */
-@ExperimentalApi
 public interface ItemSource<T> :
     PersistenceSpec<T>,
     ItemSourceOperations<T> {
@@ -21,7 +19,6 @@ public interface ItemSource<T> :
      * @param T The type of objects which will be read from and/or written to this item source
      * @param PK The type of the partition key property, either [String], [Number], or [ByteArray]
      */
-    @ExperimentalApi
     public interface PartitionKey<T, PK> :
         ItemSource<T>,
         PersistenceSpec.PartitionKey<T, PK>
@@ -33,7 +30,6 @@ public interface ItemSource<T> :
      * @param PK The type of the partition key property, either [String], [Number], or [ByteArray]
      * @param SK The type of the sort key property, either [String], [Number], or [ByteArray]
      */
-    @ExperimentalApi
     public interface CompositeKey<T, PK, SK> :
         ItemSource<T>,
         PersistenceSpec.CompositeKey<T, PK, SK>

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/MutableItem.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/MutableItem.kt
@@ -6,25 +6,21 @@ package aws.sdk.kotlin.hll.dynamodbmapper.model
 
 import aws.sdk.kotlin.hll.dynamodbmapper.model.internal.MutableItemImpl
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * A mutable representation of a low-level item in a DynamoDB table. Items consist of attributes, each of which have a
  * string name and a value.
  */
-@ExperimentalApi
 public interface MutableItem : MutableMap<String, AttributeValue>
 
 /**
  * Convert this [MutableItem] to an immutable [Item]. Changes to this instance do not affect the returned instance.
  */
-@ExperimentalApi
 public fun MutableItem.toItem(): Item = toMap().toItem()
 
 /**
  * Converts this map to a [MutableItem]
  */
-@ExperimentalApi
 public fun MutableMap<String, AttributeValue>.toMutableItem(): MutableItem = MutableItemImpl(this)
 
 /**
@@ -32,6 +28,5 @@ public fun MutableMap<String, AttributeValue>.toMutableItem(): MutableItem = Mut
  * @param pairs A collection of [Pair]<[String], [AttributeValue]> where the first value is the attribute name and the
  * second is the attribute value.
  */
-@ExperimentalApi
 public fun mutableItemOf(vararg pairs: Pair<String, AttributeValue>): MutableItem =
     MutableItemImpl(mutableMapOf(*pairs))

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/PersistenceSpec.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/PersistenceSpec.kt
@@ -6,14 +6,12 @@ package aws.sdk.kotlin.hll.dynamodbmapper.model
 
 import aws.sdk.kotlin.hll.dynamodbmapper.DynamoDbMapper
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Specifies how items can be read from and written to a specific DynamoDB location (such as a table or a secondary
  * index)
  * @param T The type of objects which will be read from and/or written to this item source
  */
-@ExperimentalApi
 public interface PersistenceSpec<T> {
     /**
      * The [DynamoDbMapper] which holds the underlying DynamoDB service client used to invoke operations
@@ -29,7 +27,6 @@ public interface PersistenceSpec<T> {
      * Specifies how items can be read from and written to a specific DynamoDB location (such as a table or a secondary
      * index) whose primary key consists of a single partition key
      */
-    @ExperimentalApi
     public interface PartitionKey<T, PK> : PersistenceSpec<T> {
         override val schema: ItemSchema.PartitionKey<T, PK>
     }
@@ -38,7 +35,6 @@ public interface PersistenceSpec<T> {
      * Specifies how items can be read from and written to a specific DynamoDB location (such as a table or a secondary
      * index) whose primary key consists of a composite of a partition key and a sort key
      */
-    @ExperimentalApi
     public interface CompositeKey<T, PK, SK> : PersistenceSpec<T> {
         override val schema: ItemSchema.CompositeKey<T, PK, SK>
     }

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/Table.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/Table.kt
@@ -6,14 +6,12 @@ package aws.sdk.kotlin.hll.dynamodbmapper.model
 
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
 import aws.sdk.kotlin.hll.dynamodbmapper.operations.TableOperations
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Represents a table in DynamoDB and an associated item schema. Operations on this table will invoke low-level
  * operations after mapping objects to items and vice versa.
  * @param T The type of objects which will be read from and/or written to this table
  */
-@ExperimentalApi
 public interface Table<T> :
     TableSpec<T>,
     TableOperations<T>,
@@ -24,7 +22,6 @@ public interface Table<T> :
      * @param T The type of objects which will be read from and/or written to this table
      * @param PK The type of the partition key property, either [String], [Number], or [ByteArray]
      */
-    @ExperimentalApi
     public interface PartitionKey<T, PK> :
         Table<T>,
         ItemSource.PartitionKey<T, PK> {
@@ -38,7 +35,6 @@ public interface Table<T> :
      * @param PK The type of the partition key property, either [String], [Number], or [ByteArray]
      * @param SK The type of the sort key property, either [String], [Number], or [ByteArray]
      */
-    @ExperimentalApi
     public interface CompositeKey<T, PK, SK> :
         Table<T>,
         ItemSource.CompositeKey<T, PK, SK> {

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/TableSpec.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/model/TableSpec.kt
@@ -5,13 +5,11 @@
 package aws.sdk.kotlin.hll.dynamodbmapper.model
 
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Specifies how items can be read from and written to a table
  * @param T The type of objects which will be read from and/or written to this table
  */
-@ExperimentalApi
 public interface TableSpec<T> : PersistenceSpec<T> {
     /**
      * The name of the table
@@ -21,7 +19,6 @@ public interface TableSpec<T> : PersistenceSpec<T> {
     /**
      * Specifies how items can be read from or written to a table whose primary key consists of a single partition key
      */
-    @ExperimentalApi
     public interface PartitionKey<T, PK> : TableSpec<T> {
         override val schema: ItemSchema.PartitionKey<T, PK>
     }
@@ -30,7 +27,6 @@ public interface TableSpec<T> : PersistenceSpec<T> {
      * Specifies how items can be read from or written to a table  whose primary key consists of a composite of a
      * partition key and a sort key
      */
-    @ExperimentalApi
     public interface CompositeKey<T, PK, SK> : TableSpec<T> {
         override val schema: ItemSchema.CompositeKey<T, PK, SK>
     }

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/DeserializeInput.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/DeserializeInput.kt
@@ -6,7 +6,6 @@ package aws.sdk.kotlin.hll.dynamodbmapper.pipeline
 
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.internal.DeserializeInputImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.sdk.kotlin.services.dynamodb.model.GetItemResponse as LowLevelGetItemResponse
 
 /**
@@ -14,7 +13,6 @@ import aws.sdk.kotlin.services.dynamodb.model.GetItemResponse as LowLevelGetItem
  * @param T The type of objects being converted to/from DynamoDB items
  * @param LRes The type of low-level response object (e.g., [LowLevelGetItemResponse])
  */
-@ExperimentalApi
 public interface DeserializeInput<T, LRes> {
     /**
      * The low-level response which is to be deserialized into a high-level response object
@@ -34,7 +32,6 @@ public interface DeserializeInput<T, LRes> {
  * @param lowLevelResponse The low-level response which is to be deserialized into a high-level response object
  * @param deserializeSchema The [ItemSchema] to use for deserializing items into objects
  */
-@ExperimentalApi
 public fun <T, LRes> DeserializeInput(
     lowLevelResponse: LRes,
     deserializeSchema: ItemSchema<T>,

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/HReqContext.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/HReqContext.kt
@@ -7,14 +7,12 @@ package aws.sdk.kotlin.hll.dynamodbmapper.pipeline
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
 import aws.sdk.kotlin.hll.dynamodbmapper.operations.GetItemRequest
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.internal.HReqContextImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Contextual data for stages in the pipeline dealing with high-level requests (i.e., before serialization)
  * @param T The type of objects being converted to/from DynamoDB items
  * @param HReq The type of high-level request object (e.g., [GetItemRequest])
  */
-@ExperimentalApi
 public interface HReqContext<T, HReq> : SerializeInput<T, HReq> {
 
     /**
@@ -39,7 +37,6 @@ public interface HReqContext<T, HReq> : SerializeInput<T, HReq> {
  * @param mapperContext Additional, generalized context which may be useful to interceptors
  * @param error The most recent error which occurred, if any. Defaults to null.
  */
-@ExperimentalApi
 public fun <T, HReq> HReqContext(
     highLevelRequest: HReq,
     serializeSchema: ItemSchema<T>,

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/HResContext.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/HResContext.kt
@@ -8,7 +8,6 @@ import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
 import aws.sdk.kotlin.hll.dynamodbmapper.operations.GetItemRequest
 import aws.sdk.kotlin.hll.dynamodbmapper.operations.GetItemResponse
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.internal.HResContextImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.sdk.kotlin.services.dynamodb.model.GetItemRequest as LowLevelGetItemRequest
 import aws.sdk.kotlin.services.dynamodb.model.GetItemResponse as LowLevelGetItemResponse
 
@@ -20,7 +19,6 @@ import aws.sdk.kotlin.services.dynamodb.model.GetItemResponse as LowLevelGetItem
  * @param LRes The type of low-level response object (e.g., [LowLevelGetItemResponse])
  * @param HRes The type of high-level response object (e.g., [GetItemResponse])
  */
-@ExperimentalApi
 public interface HResContext<T, HReq, LReq, LRes, HRes> : LResContext<T, HReq, LReq, LRes> {
     /**
      * The high-level response to return to the caller
@@ -43,7 +41,6 @@ public interface HResContext<T, HReq, LReq, LRes, HRes> : LResContext<T, HReq, L
  * @param highLevelResponse The high-level response to return to the caller
  * @param error The most recent error which occurred, if any. Defaults to null.
  */
-@ExperimentalApi
 public fun <T, HReq, LReq, LRes, HRes> HResContext(
     highLevelRequest: HReq,
     serializeSchema: ItemSchema<T>,

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/Interceptor.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/Interceptor.kt
@@ -9,7 +9,6 @@ import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
 import aws.sdk.kotlin.hll.dynamodbmapper.operations.GetItemRequest
 import aws.sdk.kotlin.hll.dynamodbmapper.operations.GetItemResponse
 import aws.sdk.kotlin.services.dynamodb.DynamoDbClient
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.sdk.kotlin.services.dynamodb.model.GetItemRequest as LowLevelGetItemRequest
 import aws.sdk.kotlin.services.dynamodb.model.GetItemResponse as LowLevelGetItemResponse
 
@@ -75,7 +74,6 @@ import aws.sdk.kotlin.services.dynamodb.model.GetItemResponse as LowLevelGetItem
  * @param LRes The type of low-level response object (e.g., [LowLevelGetItemResponse])
  * @param HRes The type of high-level response object (e.g., [GetItemResponse])
  */
-@ExperimentalApi
 public interface Interceptor<T, HReq, LReq, LRes, HRes> {
     // Hooks functions are defined in the same order as pipeline execution below:
 
@@ -182,5 +180,4 @@ public interface Interceptor<T, HReq, LReq, LRes, HRes> {
 /**
  * A universal interceptor which acts on any type of high-level objects, requests, and responses
  */
-@ExperimentalApi
 public typealias InterceptorAny = Interceptor<*, *, *, *, *>

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/LReqContext.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/LReqContext.kt
@@ -7,7 +7,6 @@ package aws.sdk.kotlin.hll.dynamodbmapper.pipeline
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
 import aws.sdk.kotlin.hll.dynamodbmapper.operations.GetItemRequest
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.internal.LReqContextImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.sdk.kotlin.services.dynamodb.model.GetItemRequest as LowLevelGetItemRequest
 
 /**
@@ -17,7 +16,6 @@ import aws.sdk.kotlin.services.dynamodb.model.GetItemRequest as LowLevelGetItemR
  * @param HReq The type of high-level request object (e.g., [GetItemRequest])
  * @param LReq The type of low-level request object (e.g., [LowLevelGetItemRequest])
  */
-@ExperimentalApi
 public interface LReqContext<T, HReq, LReq> : HReqContext<T, HReq> {
     /**
      * The low-level request object which is to be used in the low-level operation invocation
@@ -36,7 +34,6 @@ public interface LReqContext<T, HReq, LReq> : HReqContext<T, HReq> {
  * @param lowLevelRequest The low-level request object which is to be used in the low-level operation invocation
  * @param error The most recent error which occurred, if any. Defaults to null.
  */
-@ExperimentalApi
 public fun <T, HReq, LReq> LReqContext(
     highLevelRequest: HReq,
     serializeSchema: ItemSchema<T>,

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/LResContext.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/LResContext.kt
@@ -7,7 +7,6 @@ package aws.sdk.kotlin.hll.dynamodbmapper.pipeline
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
 import aws.sdk.kotlin.hll.dynamodbmapper.operations.GetItemRequest
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.internal.LResContextImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.sdk.kotlin.services.dynamodb.model.GetItemRequest as LowLevelGetItemRequest
 import aws.sdk.kotlin.services.dynamodb.model.GetItemResponse as LowLevelGetItemResponse
 
@@ -19,7 +18,6 @@ import aws.sdk.kotlin.services.dynamodb.model.GetItemResponse as LowLevelGetItem
  * @param LReq The type of low-level request object (e.g., [LowLevelGetItemRequest])
  * @param LRes The type of low-level response object (e.g., [LowLevelGetItemResponse])
  */
-@ExperimentalApi
 public interface LResContext<T, HReq, LReq, LRes> :
     LReqContext<T, HReq, LReq>,
     DeserializeInput<T, LRes>
@@ -38,7 +36,6 @@ public interface LResContext<T, HReq, LReq, LRes> :
  * @param deserializeSchema The [ItemSchema] to use for deserializing items into objects
  * @param error The most recent error which occurred, if any. Defaults to null.
  */
-@ExperimentalApi
 public fun <T, HReq, LReq, LRes> LResContext(
     highLevelRequest: HReq,
     serializeSchema: ItemSchema<T>,

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/MapperContext.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/MapperContext.kt
@@ -6,13 +6,11 @@ package aws.sdk.kotlin.hll.dynamodbmapper.pipeline
 
 import aws.sdk.kotlin.hll.dynamodbmapper.model.PersistenceSpec
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.internal.MapperContextImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Holds generalized context which may be useful to interceptors
  * @param T The type of objects being converted to/from DynamoDB items
  */
-@ExperimentalApi
 public interface MapperContext<T> {
     // TODO what other fields would be useful in here?
 
@@ -33,6 +31,5 @@ public interface MapperContext<T> {
  * @param persistenceSpec The metadata about an operation invocation
  * @param operation The name of the high-level operation being invoked
  */
-@ExperimentalApi
 public fun <T> MapperContext(persistenceSpec: PersistenceSpec<T>, operation: String): MapperContext<T> =
     MapperContextImpl(persistenceSpec, operation)

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/SerializeInput.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/pipeline/SerializeInput.kt
@@ -7,14 +7,12 @@ package aws.sdk.kotlin.hll.dynamodbmapper.pipeline
 import aws.sdk.kotlin.hll.dynamodbmapper.items.ItemSchema
 import aws.sdk.kotlin.hll.dynamodbmapper.operations.GetItemRequest
 import aws.sdk.kotlin.hll.dynamodbmapper.pipeline.internal.SerializeInputImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Defines input to the serialization step of the pipeline
  * @param T The type of objects being converted to/from DynamoDB items
  * @param HReq The type of high-level request object (e.g., [GetItemRequest])
  */
-@ExperimentalApi
 public interface SerializeInput<T, HReq> {
     /**
      * The high-level request object which is to be serialized into a low-level request object
@@ -34,6 +32,5 @@ public interface SerializeInput<T, HReq> {
  * @param highLevelRequest The high-level request object which is to be serialized into a low-level request object
  * @param serializeSchema The [ItemSchema] to use for serializing objects into items
  */
-@ExperimentalApi
 public fun <T, HReq> SerializeInput(highLevelRequest: HReq, serializeSchema: ItemSchema<T>): SerializeInput<T, HReq> =
     SerializeInputImpl(highLevelRequest, serializeSchema)

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/ItemValueConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/ItemValueConverter.kt
@@ -9,11 +9,9 @@ import aws.sdk.kotlin.hll.dynamodbmapper.model.Item
 import aws.sdk.kotlin.hll.dynamodbmapper.model.toItem
 import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Converts between [Item] and [AttributeValue]. This converter is typically chained following an [ItemConverter] using
  * the `+` operator.
  */
-@ExperimentalApi
 public val ItemValueConverter: ValueConverter<Item> = Converter(AttributeValue::M) { it.asM().toItem() }

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/NullableValueConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/NullableValueConverter.kt
@@ -9,7 +9,6 @@ import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.hll.mapping.core.converters.MonoConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.reversedBy
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Converts between `null` values and
@@ -17,7 +16,6 @@ import aws.smithy.kotlin.runtime.ExperimentalApi
  * This converter is not generally useful on its own and is typically combined with a type-specific non-nullable
  * delegate in a [NullableValueConverter].
  */
-@ExperimentalApi
 public val NullValueConverter: ValueConverter<Nothing?> =
     MonoConverter<Nothing?, AttributeValue> { NULL_ATTR } reversedBy MonoConverter {
         require(it is AttributeValue.Null)
@@ -31,7 +29,6 @@ public val NullValueConverter: ValueConverter<Nothing?> =
  * @param delegate The delegate converter for non-null values
  * @param nullValueConverter A [Converter] for `null` values. The default is [NullValueConverter].
  */
-@ExperimentalApi
 @Suppress("ktlint:standard:function-naming")
 public fun <V : Any> NullableValueConverter(
     delegate: ValueConverter<V>,
@@ -54,7 +51,6 @@ public fun <V : Any> NullableValueConverter(
     return Converter(right, left)
 }
 
-@ExperimentalApi
 public fun <V : Any> ValueConverter<V>.asNullable(
     nullValueConverter: ValueConverter<Nothing?> = NullValueConverter,
 ): ValueConverter<V?> = NullableValueConverter(this, nullValueConverter)

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/ValueConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/ValueConverter.kt
@@ -6,7 +6,6 @@ package aws.sdk.kotlin.hll.dynamodbmapper.values
 
 import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Defines the logic for converting individual values between a high-level type [V] (e.g., [String], [Boolean], [Map])
@@ -14,5 +13,4 @@ import aws.smithy.kotlin.runtime.ExperimentalApi
  * [DynamoDB data types](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes)
  * @param V The type of high-level values which will be converted to low-level DynamoDB attribute values
  */
-@ExperimentalApi
 public typealias ValueConverter<V> = Converter<V, AttributeValue>

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/collections/ListValueConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/collections/ListValueConverter.kt
@@ -9,7 +9,6 @@ import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.hll.mapping.core.converters.collections.ListMappingConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.plus
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Converts between [List] and
@@ -18,7 +17,6 @@ import aws.smithy.kotlin.runtime.ExperimentalApi
  * with another converter which handles mapping elements to [AttributeValue], such as by using the factory function
  * [ListValueConverter].
  */
-@ExperimentalApi
 public val AttributeValueListValueConverter: ValueConverter<List<AttributeValue>> =
     Converter(AttributeValue::L, AttributeValue::asL)
 
@@ -27,7 +25,6 @@ public val AttributeValueListValueConverter: ValueConverter<List<AttributeValue>
  * @param E The type of elements in the list
  * @param delegate A converter for transforming between values of [E] and [AttributeValue]
  */
-@ExperimentalApi
 @Suppress("ktlint:standard:function-naming")
 public fun <E> ListValueConverter(
     delegate: ValueConverter<E>,

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/collections/MapValueConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/collections/MapValueConverter.kt
@@ -9,7 +9,6 @@ import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.hll.mapping.core.converters.collections.MapMappingConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.plus
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Converts between [Map] and
@@ -23,7 +22,6 @@ import aws.smithy.kotlin.runtime.ExperimentalApi
  * val instantMapConv2 = MapValueConverter.mapValuesFrom(InstantConverter.Default) // same as above
  * ```
  */
-@ExperimentalApi
 public val AttributeValueMapValueConverter: ValueConverter<Map<String, AttributeValue>> =
     Converter(AttributeValue::M, AttributeValue::asM)
 
@@ -34,7 +32,6 @@ public val AttributeValueMapValueConverter: ValueConverter<Map<String, Attribute
  * @param entryConverter A converter for transforming between entries of type `Pair<K, V>` and type
  * `Pair<String, AttributeValue>`
  */
-@ExperimentalApi
 @JvmName("MapValueConverterByEntryConverter")
 @Suppress("ktlint:standard:function-naming")
 public fun <K, V> MapValueConverter(
@@ -49,7 +46,6 @@ public fun <K, V> MapValueConverter(
  * @param keyConverter A converter for transforming between [K] keys and [String] keys
  * @param valueConverter A converter for transforming between [V] values and [AttributeValue]
  */
-@ExperimentalApi
 @JvmName("MapValueConverterByKeyAndValueConverter")
 @Suppress("ktlint:standard:function-naming")
 public fun <K, V> MapValueConverter(
@@ -64,7 +60,6 @@ public fun <K, V> MapValueConverter(
  * @param V The type of values in the map
  * @param valueConverter A converter for transforming between [V] values and [AttributeValue]
  */
-@ExperimentalApi
 @JvmName("MapValueConverterByValueConverter")
 @Suppress("ktlint:standard:function-naming")
 public fun <V> MapValueConverter(

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/collections/NumberSetValueConverters.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/collections/NumberSetValueConverters.kt
@@ -22,12 +22,10 @@ import aws.sdk.kotlin.hll.mapping.core.converters.collections.SetMappingConverte
 import aws.sdk.kotlin.hll.mapping.core.converters.collections.SetToListConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.plus
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Namespace for containing various conversion utilities dealing with numerical set conversion
  */
-@ExperimentalApi
 public object NumberSetValueConverters {
     /**
      * Converts between a [List] of [String] elements and
@@ -57,69 +55,59 @@ public object NumberSetValueConverters {
      * Converts between a [Set] of [Byte] elements and
      * [DynamoDB `NS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
      */
-    @ExperimentalApi
     public val Byte: ValueConverter<Set<Byte>> = of(NumberToStringConverters.Byte)
 
     /**
      * Converts between a [Set] of [Double] elements and
      * [DynamoDB `NS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
      */
-    @ExperimentalApi
     public val Double: ValueConverter<Set<Double>> = of(NumberToStringConverters.Double)
 
     /**
      * Converts between a [Set] of [Float] elements and
      * [DynamoDB `NS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
      */
-    @ExperimentalApi
     public val Float: ValueConverter<Set<Float>> = of(NumberToStringConverters.Float)
 
     /**
      * Converts between a [Set] of [Int] elements and
      * [DynamoDB `NS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
      */
-    @ExperimentalApi
     public val Int: ValueConverter<Set<Int>> = of(NumberToStringConverters.Int)
 
     /**
      * Converts between a [Set] of [Long] elements and
      * [DynamoDB `NS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
      */
-    @ExperimentalApi
     public val Long: ValueConverter<Set<Long>> = of(NumberToStringConverters.Long)
 
     /**
      * Converts between a [Set] of [Short] elements and
      * [DynamoDB `NS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
      */
-    @ExperimentalApi
     public val Short: ValueConverter<Set<Short>> = of(NumberToStringConverters.Short)
 
     /**
      * Converts between a [Set] of [UByte] elements and
      * [DynamoDB `NS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
      */
-    @ExperimentalApi
     public val UByte: ValueConverter<Set<UByte>> = of(NumberToStringConverters.UByte)
 
     /**
      * Converts between a [Set] of [UInt] elements and
      * [DynamoDB `NS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
      */
-    @ExperimentalApi
     public val UInt: ValueConverter<Set<UInt>> = of(NumberToStringConverters.UInt)
 
     /**
      * Converts between a [Set] of [ULong] elements and
      * [DynamoDB `NS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
      */
-    @ExperimentalApi
     public val ULong: ValueConverter<Set<ULong>> = of(NumberToStringConverters.ULong)
 
     /**
      * Converts between a [Set] of [UShort] elements and
      * [DynamoDB `NS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
      */
-    @ExperimentalApi
     public val UShort: ValueConverter<Set<UShort>> = of(NumberToStringConverters.UShort)
 }

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/collections/PrimitiveSetValueConverters.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/collections/PrimitiveSetValueConverters.kt
@@ -11,13 +11,11 @@ import aws.sdk.kotlin.hll.mapping.core.converters.collections.SetMappingConverte
 import aws.sdk.kotlin.hll.mapping.core.converters.collections.SetToListConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.plus
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Converts between a [Set] of [ByteArray] elements and
  * [DynamoDB `BS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
  */
-@ExperimentalApi
 public val ByteArraySetConverter: ValueConverter<Set<ByteArray>> = Converter(
     right = { from -> AttributeValue.Bs(from.toList()) },
     left = { to -> to.asBs().toSet() },
@@ -27,7 +25,6 @@ public val ByteArraySetConverter: ValueConverter<Set<ByteArray>> = Converter(
  * Converts between a [List] of [String] elements and
  * [DynamoDB `SS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
  */
-@ExperimentalApi
 public val StringListValueConverter: ValueConverter<List<String>> =
     Converter(AttributeValue::Ss, AttributeValue::asSs)
 
@@ -35,7 +32,6 @@ public val StringListValueConverter: ValueConverter<List<String>> =
  * Converts between a [Set] of [String] elements and
  * [DynamoDB `SS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
  */
-@ExperimentalApi
 public val StringSetValueConverter: ValueConverter<Set<String>> =
     SetToListConverter<String>() + StringListValueConverter
 
@@ -43,7 +39,6 @@ public val StringSetValueConverter: ValueConverter<Set<String>> =
  * Converts between a [Set] of [CharArray] elements and
  * [DynamoDB `SS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
  */
-@ExperimentalApi
 public val CharArraySetValueConverter: ValueConverter<Set<CharArray>> =
     SetMappingConverter(TextConverters.CharArray) + StringSetValueConverter
 
@@ -51,6 +46,5 @@ public val CharArraySetValueConverter: ValueConverter<Set<CharArray>> =
  * Converts between a [Set] of [Char] elements and
  * [DynamoDB `SS` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.SetTypes)
  */
-@ExperimentalApi
 public val CharSetValueConverter: ValueConverter<Set<Char>> =
     SetMappingConverter(TextConverters.Char) + StringSetValueConverter

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/scalars/BooleanValueConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/scalars/BooleanValueConverter.kt
@@ -7,17 +7,14 @@ package aws.sdk.kotlin.hll.dynamodbmapper.values.scalars
 import aws.sdk.kotlin.hll.dynamodbmapper.values.ValueConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Converts between [Boolean] and
  * [DynamoDB `BOOL` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Boolean)
  */
-@ExperimentalApi
 public val BooleanValueConverter: ValueConverter<Boolean> = Converter(AttributeValue::Bool, AttributeValue::asBool)
 
 /**
  * Converts between [Boolean] and [String]
  */
-@ExperimentalApi
 public val BooleanToStringConverter: Converter<Boolean, String> = Converter({ it.toString() }, { it.toBoolean() })

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/scalars/ByteArrayValueConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/scalars/ByteArrayValueConverter.kt
@@ -7,11 +7,9 @@ package aws.sdk.kotlin.hll.dynamodbmapper.values.scalars
 import aws.sdk.kotlin.hll.dynamodbmapper.values.ValueConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Converts between [ByteArray] and
  * [DynamoDB `B` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Binary)
  */
-@ExperimentalApi
 public val ByteArrayValueConverter: ValueConverter<ByteArray> = Converter(AttributeValue::B, AttributeValue::asB)

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/scalars/EnumValueConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/scalars/EnumValueConverter.kt
@@ -7,13 +7,11 @@ package aws.sdk.kotlin.hll.dynamodbmapper.values.scalars
 import aws.sdk.kotlin.hll.dynamodbmapper.values.ValueConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.hll.mapping.core.converters.plus
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Instantiates a new [ValueConverter] for enums of type [E]
  * @param E The [Enum] type for which to create a [ValueConverter]
  */
-@ExperimentalApi
 @Suppress("ktlint:standard:function-naming")
 public inline fun <reified E : Enum<E>> EnumValueConverter(): ValueConverter<E> =
     Converter<E, String>({ it.name }, { enumValueOf(it) }) + StringValueConverter

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/scalars/NumberValueConverters.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/scalars/NumberValueConverters.kt
@@ -8,12 +8,10 @@ import aws.sdk.kotlin.hll.dynamodbmapper.values.ValueConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.hll.mapping.core.converters.plus
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Namespace for containing various conversion utilities dealing with number conversion
  */
-@ExperimentalApi
 public object NumberValueConverters {
     /**
      * Converts between [Number] and
@@ -23,77 +21,66 @@ public object NumberValueConverters {
      * * [kotlin.Int] — If the number is in the range of [kotlin.Int.MIN_VALUE] and [kotlin.Int.MAX_VALUE] (inclusive)
      * * [kotlin.Long] — Anything else
      */
-    @ExperimentalApi
     public val Auto: ValueConverter<Number> = NumberToStringConverters.Auto + NumericalStringValueConverter
 
     /**
      * Converts between [kotlin.Byte] and
      * [DynamoDB `N` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Number)
      */
-    @ExperimentalApi
     public val Byte: ValueConverter<Byte> = NumberToStringConverters.Byte + NumericalStringValueConverter
 
     /**
      * Converts between [kotlin.Double] and
      * [DynamoDB `N` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Number)
      */
-    @ExperimentalApi
     public val Double: ValueConverter<Double> = NumberToStringConverters.Double + NumericalStringValueConverter
 
     /**
      * Converts between [kotlin.Float] and
      * [DynamoDB `N` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Number)
      */
-    @ExperimentalApi
     public val Float: ValueConverter<Float> = NumberToStringConverters.Float + NumericalStringValueConverter
 
     /**
      * Converts between [kotlin.Int] and
      * [DynamoDB `N` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Number)
      */
-    @ExperimentalApi
     public val Int: ValueConverter<Int> = NumberToStringConverters.Int + NumericalStringValueConverter
 
     /**
      * Converts between [kotlin.Long] and
      * [DynamoDB `N` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Number)
      */
-    @ExperimentalApi
     public val Long: ValueConverter<Long> = NumberToStringConverters.Long + NumericalStringValueConverter
 
     /**
      * Converts between [kotlin.Short] and
      * [DynamoDB `N` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Number)
      */
-    @ExperimentalApi
     public val Short: ValueConverter<Short> = NumberToStringConverters.Short + NumericalStringValueConverter
 
     /**
      * Converts between [kotlin.UByte] and
      * [DynamoDB `N` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Number)
      */
-    @ExperimentalApi
     public val UByte: ValueConverter<UByte> = NumberToStringConverters.UByte + NumericalStringValueConverter
 
     /**
      * Converts between [kotlin.UInt] and
      * [DynamoDB `N` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Number)
      */
-    @ExperimentalApi
     public val UInt: ValueConverter<UInt> = NumberToStringConverters.UInt + NumericalStringValueConverter
 
     /**
      * Converts between [kotlin.ULong] and
      * [DynamoDB `N` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Number)
      */
-    @ExperimentalApi
     public val ULong: ValueConverter<ULong> = NumberToStringConverters.ULong + NumericalStringValueConverter
 
     /**
      * Converts between [kotlin.UShort] and
      * [DynamoDB `N` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Number)
      */
-    @ExperimentalApi
     public val UShort: ValueConverter<UShort> = NumberToStringConverters.UShort + NumericalStringValueConverter
 }
 

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/scalars/TextValueConverters.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/scalars/TextValueConverters.kt
@@ -8,12 +8,10 @@ import aws.sdk.kotlin.hll.dynamodbmapper.values.ValueConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.hll.mapping.core.converters.plus
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Namespace for containing various conversion utilities dealing with text conversion
  */
-@ExperimentalApi
 public object TextConverters {
     /**
      * Converts between [kotlin.CharArray] and [kotlin.String]
@@ -37,19 +35,16 @@ public object TextConverters {
  * Converts between [String] and
  * [DynamoDB `S` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.String)
  */
-@ExperimentalApi
 public val StringValueConverter: ValueConverter<String> = Converter(AttributeValue::S, AttributeValue::asS)
 
 /**
  * Converts between [CharArray] and
  * [DynamoDB `S` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.String)
  */
-@ExperimentalApi
 public val CharArrayValueConverter: ValueConverter<CharArray> = TextConverters.CharArray + StringValueConverter
 
 /**
  * Converts between [Char] and
  * [DynamoDB `S` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.String)
  */
-@ExperimentalApi
 public val CharValueConverter: ValueConverter<Char> = TextConverters.Char + StringValueConverter

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/smithytypes/DocumentValueConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/smithytypes/DocumentValueConverter.kt
@@ -17,7 +17,6 @@ import aws.sdk.kotlin.hll.mapping.core.converters.collections.ListMappingConvert
 import aws.sdk.kotlin.hll.mapping.core.converters.collections.MapMappingConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.plus
 import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.content.Document
 
 /**
@@ -29,7 +28,6 @@ import aws.smithy.kotlin.runtime.content.Document
  * * [Document.List] ↔ [DynamoDB `L` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Document.List)
  * * [Document.Map] ↔ [DynamoDB `M` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.Document.Map)
  */
-@ExperimentalApi
 public class DocumentValueConverter(
     private val numberValueConverter: ValueConverter<Number> = NumberValueConverters.Auto,
     private val stringValueConverter: ValueConverter<String> = StringValueConverter,
@@ -42,7 +40,6 @@ public class DocumentValueConverter(
     private val listValueConverter = ListMappingConverter(nullableConverter) + attributeValueListValueConverter
     private val mapValueConverter = MapMappingConverter(Converter.identity<String>(), nullableConverter) + attributeValueMapValueConverter
 
-    @ExperimentalApi
     public companion object {
         /**
          * The default instance of [DocumentValueConverter]

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/smithytypes/InstantValueConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/smithytypes/InstantValueConverter.kt
@@ -10,7 +10,6 @@ import aws.sdk.kotlin.hll.dynamodbmapper.values.scalars.StringValueConverter
 import aws.sdk.kotlin.hll.dynamodbmapper.values.smithytypes.InstantValueConverter.EpochS
 import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.hll.mapping.core.converters.plus
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.time.Instant
 import aws.smithy.kotlin.runtime.time.TimestampFormat
 import aws.smithy.kotlin.runtime.time.epochMilliseconds
@@ -19,7 +18,6 @@ import aws.smithy.kotlin.runtime.time.fromEpochMilliseconds
 /**
  * Provides access to [ValueConverter] types for various [Instant] representations
  */
-@ExperimentalApi
 public object InstantValueConverter {
     /**
      * Converts between [Instant] and

--- a/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/smithytypes/UrlValueConverter.kt
+++ b/hll/dynamodb-mapper/dynamodb-mapper/common/src/aws/sdk/kotlin/hll/dynamodbmapper/values/smithytypes/UrlValueConverter.kt
@@ -8,18 +8,15 @@ import aws.sdk.kotlin.hll.dynamodbmapper.values.ValueConverter
 import aws.sdk.kotlin.hll.dynamodbmapper.values.scalars.StringValueConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.hll.mapping.core.converters.plus
-import aws.smithy.kotlin.runtime.ExperimentalApi
 import aws.smithy.kotlin.runtime.net.url.Url
 
 /**
  * Converts between [Url] and [String] types
  */
-@ExperimentalApi
 public val UrlToStringConverter: Converter<Url, String> = Converter(Url::toString, Url::parse)
 
 /**
  * Converts between [Url] and
  * [DynamoDB `S` values](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes.String)
  */
-@ExperimentalApi
 public val UrlValueConverter: ValueConverter<Url> = UrlToStringConverter + StringValueConverter

--- a/hll/hll-codegen/src/main/kotlin/aws/sdk/kotlin/hll/codegen/model/Types.kt
+++ b/hll/hll-codegen/src/main/kotlin/aws/sdk/kotlin/hll/codegen/model/Types.kt
@@ -5,6 +5,7 @@
 
 package aws.sdk.kotlin.hll.codegen.model
 
+import aws.sdk.kotlin.hll.codegen.model.Types.Kotlin.String
 import aws.sdk.kotlin.runtime.InternalSdkApi
 
 /**
@@ -14,7 +15,6 @@ import aws.sdk.kotlin.runtime.InternalSdkApi
 public object Types {
     @InternalSdkApi
     public object Smithy {
-        public val ExperimentalApi: TypeRef = TypeRef("aws.smithy.kotlin.runtime", "ExperimentalApi")
         public val Instant: TypeRef = TypeRef("aws.smithy.kotlin.runtime.time", "Instant")
         public val Url: TypeRef = TypeRef("aws.smithy.kotlin.runtime.net.url", "Url")
         public val Document: TypeRef = TypeRef("aws.smithy.kotlin.runtime.content", "Document")

--- a/hll/hll-codegen/src/main/kotlin/aws/sdk/kotlin/hll/codegen/rendering/BuilderRenderer.kt
+++ b/hll/hll-codegen/src/main/kotlin/aws/sdk/kotlin/hll/codegen/rendering/BuilderRenderer.kt
@@ -43,7 +43,6 @@ public class BuilderRenderer(
 
         val genericParams = members.flatMap { it.type.genericVars() }.asParamsList()
 
-        write("@#T", Types.Smithy.ExperimentalApi)
         withBlock("#Lclass #L#L {", "}", ctx.attributes.visibility, builderName, genericParams) {
             members.forEach(::renderProperty)
             blankLine()

--- a/hll/hll-mapping-core/common/src/aws/sdk/kotlin/hll/mapping/core/converters/Converter.kt
+++ b/hll/hll-mapping-core/common/src/aws/sdk/kotlin/hll/mapping/core/converters/Converter.kt
@@ -5,7 +5,6 @@
 package aws.sdk.kotlin.hll.mapping.core.converters
 
 import aws.sdk.kotlin.hll.mapping.core.converters.internal.ConverterImpl
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * A type for two-way conversion between a **left** type [L] and **right** type [R]. As a general convention, **left**
@@ -16,7 +15,6 @@ import aws.smithy.kotlin.runtime.ExperimentalApi
  * @param L The **left** type
  * @param R The **right** type
  */
-@ExperimentalApi
 public interface Converter<L, R> {
     public companion object {
         public fun <T> identity(): Converter<T, T> = Converter({ it }, { it })
@@ -50,7 +48,6 @@ public interface Converter<L, R> {
  * @param right A converter instance for converting one-way from [L] to [R]
  * @param left A converter instance for converting one-way from [R] to [L]
  */
-@ExperimentalApi
 public fun <L, R> Converter(right: MonoConverter<L, R>, left: MonoConverter<R, L>): Converter<L, R> =
     ConverterImpl(right, left)
 
@@ -62,6 +59,5 @@ public fun <L, R> Converter(right: MonoConverter<L, R>, left: MonoConverter<R, L
  * @param R The **right** type of the next converter
  * @param next The subsequent converter to chain
  */
-@ExperimentalApi
 public operator fun <L, M, R> Converter<L, M>.plus(next: Converter<M, R>): Converter<L, R> =
     Converter(this.right + next.right, next.left + this.left)

--- a/hll/hll-mapping-core/common/src/aws/sdk/kotlin/hll/mapping/core/converters/MonoConverter.kt
+++ b/hll/hll-mapping-core/common/src/aws/sdk/kotlin/hll/mapping/core/converters/MonoConverter.kt
@@ -4,15 +4,12 @@
  */
 package aws.sdk.kotlin.hll.mapping.core.converters
 
-import aws.smithy.kotlin.runtime.ExperimentalApi
-
 /**
  * A type for one-way conversion from values of type [A] to values of type [B]. A symmetrical pair of one-way converters
  * form the two halves of a [Converter] which provides two-way conversion.
  * @param A the type to convert from
  * @param B the type to convert to
  */
-@ExperimentalApi
 public fun interface MonoConverter<A, B> {
     public companion object {
         public fun <T> identity(): MonoConverter<T, T> = MonoConverter { it }
@@ -31,7 +28,6 @@ public fun interface MonoConverter<A, B> {
  * @param C The "to" type of the next converter
  * @param next The subsequent converter to chain
  */
-@ExperimentalApi
 public operator fun <A, B, C> MonoConverter<A, B>.plus(next: MonoConverter<B, C>): MonoConverter<A, C> =
     MonoConverter { next.convert(this.convert(it)) }
 
@@ -41,6 +37,5 @@ public operator fun <A, B, C> MonoConverter<A, B>.plus(next: MonoConverter<B, C>
  * @param B The "from" type of the other converter and the "to" type of this converter
  * @param other The other converter to pair with
  */
-@ExperimentalApi
 public infix fun <A, B> MonoConverter<A, B>.reversedBy(other: MonoConverter<B, A>): Converter<A, B> =
     Converter(this, other)

--- a/hll/hll-mapping-core/common/src/aws/sdk/kotlin/hll/mapping/core/converters/collections/CollectionConverters.kt
+++ b/hll/hll-mapping-core/common/src/aws/sdk/kotlin/hll/mapping/core/converters/collections/CollectionConverters.kt
@@ -5,8 +5,6 @@
 package aws.sdk.kotlin.hll.mapping.core.converters.collections
 
 import aws.sdk.kotlin.hll.mapping.core.converters.Converter
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
-@ExperimentalApi
 @Suppress("ktlint:standard:function-naming")
 public fun <E> SetToListConverter(): Converter<Set<E>, List<E>> = Converter({ it.toList() }, { it.toSet() })

--- a/hll/hll-mapping-core/common/src/aws/sdk/kotlin/hll/mapping/core/converters/collections/ListMappingConverters.kt
+++ b/hll/hll-mapping-core/common/src/aws/sdk/kotlin/hll/mapping/core/converters/collections/ListMappingConverters.kt
@@ -7,7 +7,6 @@ package aws.sdk.kotlin.hll.mapping.core.converters.collections
 import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.hll.mapping.core.converters.MonoConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.reversedBy
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Creates a list-mapping [MonoConverter] which turns values of type `List<L>` into values of type `List<R>`
@@ -15,7 +14,6 @@ import aws.smithy.kotlin.runtime.ExperimentalApi
  * @param B The element type to convert to
  * @param delegate A [MonoConverter] from type [A] to type [B] to use for each list element
  */
-@ExperimentalApi
 @Suppress("ktlint:standard:function-naming")
 public fun <A, B> ListMappingMonoConverter(delegate: MonoConverter<A, B>): MonoConverter<List<A>, List<B>> =
     MonoConverter { it.map(delegate::convert) }
@@ -26,7 +24,6 @@ public fun <A, B> ListMappingMonoConverter(delegate: MonoConverter<A, B>): MonoC
  * @param L The **left** element type
  * @param R The **right** element type
  */
-@ExperimentalApi
 @Suppress("ktlint:standard:function-naming")
 public fun <L, R> ListMappingConverter(delegate: Converter<L, R>): Converter<List<L>, List<R>> =
     ListMappingMonoConverter(delegate.right) reversedBy ListMappingMonoConverter(delegate.left)

--- a/hll/hll-mapping-core/common/src/aws/sdk/kotlin/hll/mapping/core/converters/collections/MapMappingConverters.kt
+++ b/hll/hll-mapping-core/common/src/aws/sdk/kotlin/hll/mapping/core/converters/collections/MapMappingConverters.kt
@@ -7,7 +7,6 @@ package aws.sdk.kotlin.hll.mapping.core.converters.collections
 import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.hll.mapping.core.converters.MonoConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.reversedBy
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Creates a map-mapping [MonoConverter] which turns values of type `Map<AK, AV>` into values of type `Map<BK, BV>`
@@ -17,7 +16,6 @@ import aws.smithy.kotlin.runtime.ExperimentalApi
  * @param BV The value type to convert to
  * @param delegate A [MonoConverter] from type `Pair<AK, AV>` to type `Pair<BK, BV>` to use for each map entry
  */
-@ExperimentalApi
 @Suppress("ktlint:standard:function-naming")
 public fun <AK, AV, BK, BV> MapMappingMonoConverter(
     delegate: MonoConverter<Pair<AK, AV>, Pair<BK, BV>>,
@@ -36,7 +34,6 @@ public fun <AK, AV, BK, BV> MapMappingMonoConverter(
  * @param keyDelegate A [MonoConverter] from type [AK] to type [BK] to use for each map key
  * @param valueDelegate A [MonoConverter] from type [AV] to type [BV] to use for each map value
  */
-@ExperimentalApi
 @Suppress("ktlint:standard:function-naming")
 public fun <AK, AV, BK, BV> MapMappingMonoConverter(
     keyDelegate: MonoConverter<AK, BK>,
@@ -56,7 +53,6 @@ public fun <AK, AV, BK, BV> MapMappingMonoConverter(
  * @param RV The **right** value type
  * @param delegate A [Converter] between values of type `Pair<AK, AV>` and type `Pair<BK, BV>` to use for each map entry
  */
-@ExperimentalApi
 @Suppress("ktlint:standard:function-naming")
 public fun <LK, LV, RK, RV> MapMappingConverter(
     delegate: Converter<Pair<LK, LV>, Pair<RK, RV>>,
@@ -73,7 +69,6 @@ public fun <LK, LV, RK, RV> MapMappingConverter(
  * @param keyDelegate A [Converter] between values of type [LK] and type [RK] to use for each map key
  * @param valueDelegate A [Converter] between values of type [LV] to type [RV] to use for each map value
  */
-@ExperimentalApi
 @Suppress("ktlint:standard:function-naming")
 public fun <LK, LV, RK, RV> MapMappingConverter(
     keyDelegate: Converter<LK, RK>,

--- a/hll/hll-mapping-core/common/src/aws/sdk/kotlin/hll/mapping/core/converters/collections/SetMappingConverters.kt
+++ b/hll/hll-mapping-core/common/src/aws/sdk/kotlin/hll/mapping/core/converters/collections/SetMappingConverters.kt
@@ -7,7 +7,6 @@ package aws.sdk.kotlin.hll.mapping.core.converters.collections
 import aws.sdk.kotlin.hll.mapping.core.converters.Converter
 import aws.sdk.kotlin.hll.mapping.core.converters.MonoConverter
 import aws.sdk.kotlin.hll.mapping.core.converters.reversedBy
-import aws.smithy.kotlin.runtime.ExperimentalApi
 
 /**
  * Creates a set-mapping [MonoConverter] which turns values of type `Set<L>` into values of type `Set<R>`
@@ -15,7 +14,6 @@ import aws.smithy.kotlin.runtime.ExperimentalApi
  * @param B The element type to convert to
  * @param delegate A [MonoConverter] from type [A] to type [B] to use for each set element
  */
-@ExperimentalApi
 @Suppress("ktlint:standard:function-naming")
 public fun <A, B> SetMappingMonoConverter(delegate: MonoConverter<A, B>): MonoConverter<Set<A>, Set<B>> =
     MonoConverter { it.map(delegate::convert).toSet() }
@@ -26,7 +24,6 @@ public fun <A, B> SetMappingMonoConverter(delegate: MonoConverter<A, B>): MonoCo
  * @param L The **left** element type
  * @param R The **right** element type
  */
-@ExperimentalApi
 @Suppress("ktlint:standard:function-naming")
 public fun <L, R> SetMappingConverter(delegate: Converter<L, R>): Converter<Set<L>, Set<R>> =
     SetMappingMonoConverter(delegate.right) reversedBy SetMappingMonoConverter(delegate.left)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#

Related to #472 

## Description of changes

This change removes all `@ExperimentalApi` opt-in annotations from public DynamoDB Mapper APIs in anticipation of GA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
