### PR TITLE
chore: bump smithy-kotlin version

### DIFF
--- a/.changes/653e5b0c-dd12-43ee-9c47-e3ef84cd7bc4.json
+++ b/.changes/653e5b0c-dd12-43ee-9c47-e3ef84cd7bc4.json
@@ -1,0 +1,5 @@
+{
+    "id": "653e5b0c-dd12-43ee-9c47-e3ef84cd7bc4",
+    "type": "bugfix",
+    "description": "Upgrade to **smithy-kotlin** [**v1.5.21**](https://github.com/smithy-lang/smithy-kotlin/releases/tag/v1.5.21) to pick up bug fixes for logging context"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,8 +12,8 @@ atomicfu-version = "0.29.0"
 binary-compatibility-validator-version = "0.18.0"
 
 # smithy-kotlin codegen and runtime are versioned separately
-smithy-kotlin-runtime-version = "1.5.20"
-smithy-kotlin-codegen-version = "0.35.20"
+smithy-kotlin-runtime-version = "1.5.21"
+smithy-kotlin-codegen-version = "0.35.21"
 
 # codegen
 smithy-version = "1.62.0"


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change upgrades **smithy-kotlin** to [**v1.5.21**](https://github.com/smithy-lang/smithy-kotlin/releases/tag/v1.5.21) to pick up [bug fixes for logging context](https://github.com/smithy-lang/smithy-kotlin/pull/1463).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
