### PR TITLE
chore: add DynamoDB Mapper libraries to the generated BOM and Version Catalog

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -20,7 +20,7 @@ group = "aws.sdk.kotlin"
 version = sdkVersion
 description = "Provides a BOM"
 
-val evaluateAfter = listOf(":services", ":aws-runtime", ":tests", ":codegen")
+val evaluateAfter = listOf(":services", ":aws-runtime", ":tests", ":codegen", ":hll")
 evaluateAfter.forEach { evaluationDependsOn(it) }
 
 fun createBomConstraintsAndVersionCatalog() {
@@ -43,6 +43,7 @@ fun createBomConstraintsAndVersionCatalog() {
                     val prefix = when {
                         subproject.path.contains(":services") -> "services-"
                         subproject.path.contains(":aws-runtime") -> "runtime-"
+                        subproject.path.contains(":hll") && !subproject.name.startsWith("hll-") -> "hll-"
                         else -> ""
                     }
                     val alias = prefix + artifactId(target)


### PR DESCRIPTION
## Issue \#

Related to #472 

## Description of changes

This change adds various DynamoDB Mapper modules to our generated BOM and version catalog. Version catalog diff:

```diff
@@ -6,6 +6,12 @@ format.version = "1.1"
 
 [libraries]
 bom = {group = "aws.sdk.kotlin", name = "bom", version = "1.5.99-SNAPSHOT" }
+hll-dynamodb-mapper = {group = "aws.sdk.kotlin", name = "dynamodb-mapper", version = "1.5.99-SNAPSHOT" }
+hll-dynamodb-mapper-annotations = {group = "aws.sdk.kotlin", name = "dynamodb-mapper-annotations", version = "1.5.99-SNAPSHOT" }
+hll-dynamodb-mapper-annotations-jvm = {group = "aws.sdk.kotlin", name = "dynamodb-mapper-annotations-jvm", version = "1.5.99-SNAPSHOT" }
+hll-dynamodb-mapper-jvm = {group = "aws.sdk.kotlin", name = "dynamodb-mapper-jvm", version = "1.5.99-SNAPSHOT" }
+hll-mapping-core = {group = "aws.sdk.kotlin", name = "hll-mapping-core", version = "1.5.99-SNAPSHOT" }
+hll-mapping-core-jvm = {group = "aws.sdk.kotlin", name = "hll-mapping-core-jvm", version = "1.5.99-SNAPSHOT" }
 runtime-aws-config = {group = "aws.sdk.kotlin", name = "aws-config", version = "1.5.99-SNAPSHOT" }
 runtime-aws-config-jvm = {group = "aws.sdk.kotlin", name = "aws-config-jvm", version = "1.5.99-SNAPSHOT" }
 runtime-aws-core = {group = "aws.sdk.kotlin", name = "aws-core", version = "1.5.99-SNAPSHOT" }
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
