### PR TITLE
fix: repair broken service benchmarks and re-baseline

### DIFF
--- a/tests/benchmarks/service-benchmarks/README.md
+++ b/tests/benchmarks/service-benchmarks/README.md
@@ -9,47 +9,47 @@ are complete
 Ensure all services, including `iam`, have been generated before proceeding with the benchmarks. To run the benchmarks:
 * `./gradlew build`
   This builds the whole SDK.
-* `./gradlew :tests:benchmarks:service-benchmarks:run`
+* `./gradlew :tests:benchmarks:service-benchmarks:jvmRun`
   This runs the benchmark suite and prints the results to the console formatted as a Markdown table.
 
-## Baseline as of 3/26/2024
+## Baseline as of 1/5/2026
 
 The following benchmark run serves as a baseline for future runs:
 
 ### Environment
 
-| Hardware type  | Operating system | SDK version     |
-|----------------|------------------|-----------------|
-| EC2 m5.4xlarge | Amazon Linux 2   | 1.1.4 |
+| Instance type   | Operating system | SDK version |
+|-----------------|------------------|-------------|
+| EC2 m7i.4xlarge | Amazon Linux 2   | 1.5.113     |
 
 ### Results
 
-|                       | Overhead (ms) |    n |   min |   avg |   med |   p90 |   p99 |    max |
-| :---                  |          ---: | ---: |  ---: |  ---: |  ---: |  ---: |  ---: |   ---: |
-| **S3**                |               |      |       |       |       |       |       |        |
-|   —HeadObject         |               | 1637 | 0.445 | 0.628 | 0.517 | 0.655 | 6.427 | 10.388 |
-|   —PutObject          |               |  741 | 0.442 | 0.624 | 0.517 | 0.591 | 5.214 | 11.596 |
-| **SNS**               |               |      |       |       |       |       |       |        |
-|   —GetTopicAttributes |               | 4269 | 0.294 | 0.502 | 0.392 | 0.565 | 6.191 | 29.866 |
-|   —Publish            |               | 1089 | 0.255 | 0.428 | 0.337 | 0.384 | 3.072 |  9.253 |
-| **STS**               |               |      |       |       |       |       |       |        |
-|   —AssumeRole         |               | 1273 | 0.290 | 0.444 | 0.402 | 0.524 | 0.596 |  7.902 |
-|   —GetCallerIdentity  |               | 7039 | 0.225 | 0.286 | 0.258 | 0.286 | 0.360 | 11.254 |
-| **CloudWatch**        |               |      |       |       |       |       |       |        |
-|   —GetMetricData      |               | 1500 | 0.245 | 0.869 | 0.325 | 4.129 | 5.988 |  6.793 |
-|   —PutMetricData      |               | 3238 | 0.191 | 0.654 | 0.221 | 3.313 | 4.846 |  9.071 |
-| **CloudWatch Events** |               |      |       |       |       |       |       |        |
-|   —DescribeEventBus   |               | 1500 | 0.223 | 0.395 | 0.312 | 0.498 | 4.932 | 10.820 |
-|   —PutEvents          |               | 7224 | 0.230 | 0.323 | 0.271 | 0.312 | 4.112 |  6.740 |
-| **DynamoDB**          |               |      |       |       |       |       |       |        |
-|   —GetItem            |               | 5254 | 0.210 | 0.251 | 0.246 | 0.268 | 0.293 |  3.347 |
-|   —PutItem            |               | 3361 | 0.205 | 0.268 | 0.263 | 0.301 | 0.323 |  2.693 |
-| **S3Express**         |               |      |       |       |       |       |       |        |
-|   —PutObject          |               | 2077 | 0.659 | 0.722 | 0.709 | 0.734 | 0.772 |  7.732 |
-|   —GetObject          |               | 3458 | 0.275 | 0.316 | 0.301 | 0.328 | 0.363 |  9.233 |
-| **Secrets Manager**   |               |      |       |       |       |       |       |        |
-|   —GetSecretValue     |               | 1206 | 0.282 | 0.434 | 0.375 | 0.434 | 3.829 |  7.043 |
-|   —PutSecretValue     |               |  435 | 0.281 | 0.413 | 0.352 | 0.398 | 3.217 |  6.679 |
+|                       | Overhead (ms) |    n |   min |   avg |   med |   p90 |    p99 |     max |
+| :---                  |          ---: | ---: |  ---: |  ---: |  ---: |  ---: |   ---: |    ---: |
+| **S3**                |               |      |       |       |       |       |        |         |
+|   —HeadObject         |               | 1439 | 0.428 | 0.777 | 0.640 | 0.921 |  6.642 |  14.399 |
+|   —PutObject          |               |  753 | 0.345 | 0.716 | 0.627 | 0.839 |  2.814 |   9.736 |
+| **SNS**               |               |      |       |       |       |       |        |         |
+|   —GetTopicAttributes |               | 3826 | 0.196 | 0.469 | 0.314 | 0.457 | 10.428 |  13.473 |
+|   —Publish            |               | 1233 | 0.188 | 0.434 | 0.269 | 0.426 | 10.143 |  11.385 |
+| **STS**               |               |      |       |       |       |       |        |         |
+|   —AssumeRole         |               |  998 | 0.334 | 0.535 | 0.489 | 0.648 |  0.875 |   9.221 |
+|   —GetCallerIdentity  |               | 4392 | 0.169 | 0.321 | 0.285 | 0.345 |  0.458 |   9.468 |
+| **CloudWatch**        |               |      |       |       |       |       |        |         |
+|   —GetMetricData      |               | 1500 | 0.217 | 1.655 | 0.398 | 3.462 | 10.331 | 260.701 |
+|   —PutMetricData      |               | 2536 | 0.125 | 1.163 | 0.173 | 3.989 |  8.552 | 509.896 |
+| **CloudWatch Events** |               |      |       |       |       |       |        |         |
+|   —DescribeEventBus   |               | 1500 | 0.215 | 0.433 | 0.316 | 0.513 |  2.714 |  12.463 |
+|   —PutEvents          |               | 5318 | 0.138 | 0.268 | 0.171 | 0.235 |  2.707 |   8.775 |
+| **DynamoDB**          |               |      |       |       |       |       |        |         |
+|   —GetItem            |               | 4967 | 0.124 | 0.171 | 0.152 | 0.216 |  0.387 |   2.589 |
+|   —PutItem            |               | 3348 | 0.124 | 0.167 | 0.152 | 0.205 |  0.372 |   1.648 |
+| **S3Express**         |               |      |       |       |       |       |        |         |
+|   —PutObject          |               | 1677 | 0.425 | 0.600 | 0.555 | 0.738 |  0.943 |  10.733 |
+|   —GetObject          |               | 2842 | 0.207 | 0.274 | 0.256 | 0.305 |  0.422 |   9.291 |
+| **Secrets Manager**   |               |      |       |       |       |       |        |         |
+|   —GetSecretValue     |               | 1184 | 0.172 | 0.349 | 0.243 | 0.388 |  2.580 |   9.056 |
+|   —PutSecretValue     |               |  421 | 0.267 | 0.567 | 0.533 | 0.636 |  0.820 |   9.148 |
 
 ## Methodology
 
@@ -58,9 +58,9 @@ This section describes how the benchmarks actually work at a high level:
 ### Selection criteria
 
 These benchmarks select a handful of services to test against. The selection criterion is the top 7 services by traffic
-coming from the AWS SDK for Kotlin (i.e., not from other SDKs, console, etc.). As of 7/28, those top 7 services are S3,
-SNS, STS, CloudWatch, CloudWatch Events, DynamoDB, and Pinpoint (in descending order). However, Pinpoint has strict 
-throttles that make benchmarking impossible, so Secrets Manager is selected instead.
+coming from the AWS SDK for Kotlin (i.e., not from other SDKs, console, etc.). As of 7/28/2023, those top 7 services
+were: S3, SNS, STS, CloudWatch, CloudWatch Events, DynamoDB, and Pinpoint (in descending order). However, Pinpoint has
+strict throttling limits that make benchmarking impossible, so Secrets Manager is selected instead.
 
 For each service, two APIs are selected roughly corresponding to a read and a write operation (e.g., S3::HeadObject is
 a read operation and S3::PutObject is a write operation). Efforts are made to ensure that the APIs selected are the top
@@ -87,8 +87,8 @@ Benchmarks are run sequentially in a single thread. This is the high-level workf
 
 A custom [benchmark-specific telemetry provider][1] is used to instrument each service client. This provider solely
 handles metrics (i.e., no logging, tracing, etc.). It captures specific histogram metrics from an allowlist (currently
-only `smithy.client.attempt_overhead_duration`) and aggregates them for the duration of an operation run (not including
-the warmup phase). After the run is complete, the metrics are aggregated and various statistics are calculated (e.g.,
-minimum, average, median, etc.).
+only `smithy.client.call.attempt_overhead_duration`) and aggregates them for the duration of an operation run (not
+including the warmup phase). After the run is complete, the metrics are aggregated and various statistics are calculated
+(e.g., minimum, average, median, etc.).
 
-[1]: common/src/aws/sdk/kotlin/benchmarks/service/telemetry/BenchmarkTelemetryProvider.kt
+[1]: jvm/src/aws/sdk/kotlin/benchmarks/service/telemetry/BenchmarkTelemetryProvider.kt

--- a/tests/benchmarks/service-benchmarks/build.gradle.kts
+++ b/tests/benchmarks/service-benchmarks/build.gradle.kts
@@ -5,12 +5,8 @@
 import aws.sdk.kotlin.gradle.dsl.skipPublishing
 
 plugins {
-    id(libs.plugins.kotlin.jvm.get().pluginId)
-    application
-}
-
-application {
-    mainClass.set("aws.sdk.kotlin.benchmarks.service.BenchmarkHarnessKt")
+    id(libs.plugins.kotlin.multiplatform.get().pluginId)
+    alias(libs.plugins.aws.kotlin.repo.tools.kmp)
 }
 
 skipPublishing()
@@ -40,7 +36,7 @@ kotlin {
             optinAnnotations.forEach { languageSettings.optIn(it) }
         }
 
-        main {
+        jvmMain {
             dependencies {
                 api(libs.smithy.kotlin.runtime.core)
                 implementation(project(":aws-runtime:aws-core"))
@@ -51,11 +47,10 @@ kotlin {
             }
         }
     }
-}
 
-tasks.named<JavaExec>("run") {
-    classpath += objects.fileCollection().from(
-        tasks.named("compileKotlinJvm"),
-        configurations.named("jvmRuntimeClasspath"),
-    )
+    jvm {
+        mainRun {
+            mainClass.set("aws.sdk.kotlin.benchmarks.service.BenchmarkHarnessKt")
+        }
+    }
 }


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

Benchmarks appear to have been broken since [a bad merge on 7/18/2025](https://github.com/aws/aws-sdk-kotlin/commit/575f9d18ad160ecca47bb1135dde3cc304984a26#diff-10f2c0264459427c053c341425ef6b6841b8c51de00eef501911e9e8859099d2). This change re-configures the build setup, removes the use of `application` plugin since [its use with KMP is deprecated](https://kotlinlang.org/docs/whatsnew2120.html#kotlin-multiplatform-new-dsl-to-replace-gradle-s-application-plugin), and refreshes the baseline with a more current run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
