### PR TITLE
misc: remove use of smithy-kotlin-codegen-version

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -54,7 +54,7 @@ jobs:
             git fetch origin
 
             DIFF=$(git diff origin/main -- gradle/libs.versions.toml | grep '^[-+][^-+]'; exit 0)
-            SMITHY_KOTLIN_VERSION_BUMP=$(echo "$DIFF" | grep "smithy-kotlin-runtime-version =\|smithy-kotlin-codegen-version ="; exit 0)
+            SMITHY_KOTLIN_VERSION_BUMP=$(echo "$DIFF" | grep "smithy-kotlin-runtime-version ="; exit 0)
 
             if [ -z "$SMITHY_KOTLIN_VERSION_BUMP" ]; then
               echo "::error::Matching smithy-kotlin and aws-sdk-kotlin branches but no smithy-kotlin version bump"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,9 +11,8 @@ coroutines-version = "1.10.2"
 atomicfu-version = "0.29.0"
 binary-compatibility-validator-version = "0.18.0"
 
-# smithy-kotlin codegen and runtime are versioned separately
-smithy-kotlin-runtime-version = "1.5.26"
-smithy-kotlin-codegen-version = "0.35.26"
+# smithy-kotlin
+smithy-kotlin-version = "1.5.26"
 
 # codegen
 smithy-version = "1.64.0"
@@ -55,47 +54,47 @@ ksp-gradle-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j-version" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j-version" }
 
-smithy-kotlin-aws-credentials = { module = "aws.smithy.kotlin:aws-credentials", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-aws-event-stream = { module = "aws.smithy.kotlin:aws-event-stream", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-aws-json-protocols = { module = "aws.smithy.kotlin:aws-json-protocols", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-aws-protocol-core = { module = "aws.smithy.kotlin:aws-protocol-core", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-aws-signing-common = { module = "aws.smithy.kotlin:aws-signing-common", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-aws-signing-crt = { module = "aws.smithy.kotlin:aws-signing-crt", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-aws-signing-default = { module = "aws.smithy.kotlin:aws-signing-default", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-aws-signing-tests = { module = "aws.smithy.kotlin:aws-signing-tests", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-aws-xml-protocols = { module = "aws.smithy.kotlin:aws-xml-protocols", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-crt-util = { module = "aws.smithy.kotlin:crt-util", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-http = { module = "aws.smithy.kotlin:http", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-http-auth = { module = "aws.smithy.kotlin:http-auth", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-http-auth-api = { module = "aws.smithy.kotlin:http-auth-api", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-http-auth-aws = { module = "aws.smithy.kotlin:http-auth-aws", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-http-client = { module = "aws.smithy.kotlin:http-client", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-http-client-engine-crt = { module = "aws.smithy.kotlin:http-client-engine-crt", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-http-client-engine-default = { module = "aws.smithy.kotlin:http-client-engine-default", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-http-client-engine-okhttp = { module = "aws.smithy.kotlin:http-client-engine-okhttp", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-http-client-engine-okhttp4 = { module = "aws.smithy.kotlin:http-client-engine-okhttp4", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-http-test = { module = "aws.smithy.kotlin:http-test", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-identity-api = { module = "aws.smithy.kotlin:identity-api", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-logging-slf4j2 = { module = "aws.smithy.kotlin:logging-slf4j2", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-runtime-core = { module = "aws.smithy.kotlin:runtime-core", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-serde = { module = "aws.smithy.kotlin:serde", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-serde-cbor = { module = "aws.smithy.kotlin:serde-cbor", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-serde-form-url = { module = "aws.smithy.kotlin:serde-form-url", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-serde-json = { module = "aws.smithy.kotlin:serde-json", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-serde-xml = { module = "aws.smithy.kotlin:serde-xml", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-smithy-client = { module = "aws.smithy.kotlin:smithy-client", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-smithy-rpcv2-protocols = { module = "aws.smithy.kotlin:smithy-rpcv2-protocols", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-smithy-test = { module = "aws.smithy.kotlin:smithy-test", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-telemetry-api = { module = "aws.smithy.kotlin:telemetry-api", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-telemetry-defaults = { module = "aws.smithy.kotlin:telemetry-defaults", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-telemetry-provider-micrometer = { module = "aws.smithy.kotlin:telemetry-provider-micrometer", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-telemetry-provider-otel = { module = "aws.smithy.kotlin:telemetry-provider-otel", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-test-suite = { module = "aws.smithy.kotlin:test-suite", version.ref = "smithy-kotlin-runtime-version" }
-smithy-kotlin-testing = { module = "aws.smithy.kotlin:testing", version.ref = "smithy-kotlin-runtime-version" }
+smithy-kotlin-aws-credentials = { module = "aws.smithy.kotlin:aws-credentials", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-aws-event-stream = { module = "aws.smithy.kotlin:aws-event-stream", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-aws-json-protocols = { module = "aws.smithy.kotlin:aws-json-protocols", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-aws-protocol-core = { module = "aws.smithy.kotlin:aws-protocol-core", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-aws-signing-common = { module = "aws.smithy.kotlin:aws-signing-common", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-aws-signing-crt = { module = "aws.smithy.kotlin:aws-signing-crt", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-aws-signing-default = { module = "aws.smithy.kotlin:aws-signing-default", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-aws-signing-tests = { module = "aws.smithy.kotlin:aws-signing-tests", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-aws-xml-protocols = { module = "aws.smithy.kotlin:aws-xml-protocols", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-crt-util = { module = "aws.smithy.kotlin:crt-util", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-http = { module = "aws.smithy.kotlin:http", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-http-auth = { module = "aws.smithy.kotlin:http-auth", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-http-auth-api = { module = "aws.smithy.kotlin:http-auth-api", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-http-auth-aws = { module = "aws.smithy.kotlin:http-auth-aws", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-http-client = { module = "aws.smithy.kotlin:http-client", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-http-client-engine-crt = { module = "aws.smithy.kotlin:http-client-engine-crt", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-http-client-engine-default = { module = "aws.smithy.kotlin:http-client-engine-default", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-http-client-engine-okhttp = { module = "aws.smithy.kotlin:http-client-engine-okhttp", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-http-client-engine-okhttp4 = { module = "aws.smithy.kotlin:http-client-engine-okhttp4", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-http-test = { module = "aws.smithy.kotlin:http-test", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-identity-api = { module = "aws.smithy.kotlin:identity-api", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-logging-slf4j2 = { module = "aws.smithy.kotlin:logging-slf4j2", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-runtime-core = { module = "aws.smithy.kotlin:runtime-core", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-serde = { module = "aws.smithy.kotlin:serde", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-serde-cbor = { module = "aws.smithy.kotlin:serde-cbor", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-serde-form-url = { module = "aws.smithy.kotlin:serde-form-url", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-serde-json = { module = "aws.smithy.kotlin:serde-json", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-serde-xml = { module = "aws.smithy.kotlin:serde-xml", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-smithy-client = { module = "aws.smithy.kotlin:smithy-client", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-smithy-rpcv2-protocols = { module = "aws.smithy.kotlin:smithy-rpcv2-protocols", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-smithy-test = { module = "aws.smithy.kotlin:smithy-test", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-telemetry-api = { module = "aws.smithy.kotlin:telemetry-api", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-telemetry-defaults = { module = "aws.smithy.kotlin:telemetry-defaults", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-telemetry-provider-micrometer = { module = "aws.smithy.kotlin:telemetry-provider-micrometer", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-telemetry-provider-otel = { module = "aws.smithy.kotlin:telemetry-provider-otel", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-test-suite = { module = "aws.smithy.kotlin:test-suite", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-testing = { module = "aws.smithy.kotlin:testing", version.ref = "smithy-kotlin-version" }
 
-smithy-kotlin-codegen = { module = "software.amazon.smithy.kotlin:smithy-kotlin-codegen", version.ref = "smithy-kotlin-codegen-version" }
-smithy-kotlin-codegen-testutils = { module = "software.amazon.smithy.kotlin:smithy-kotlin-codegen-testutils", version.ref = "smithy-kotlin-codegen-version" }
-smithy-aws-kotlin-codegen = { module = "software.amazon.smithy.kotlin:smithy-aws-kotlin-codegen", version.ref = "smithy-kotlin-codegen-version" }
+smithy-kotlin-codegen = { module = "aws.smithy.kotlin:codegen", version.ref = "smithy-kotlin-version" }
+smithy-kotlin-codegen-testutils = { module = "aws.smithy.kotlin:codegen-testutils", version.ref = "smithy-kotlin-version" }
+smithy-aws-kotlin-codegen = { module = "aws.smithy.kotlin:aws-codegen", version.ref = "smithy-kotlin-version" }
 
 smithy-codegen-core = { module = "software.amazon.smithy:smithy-codegen-core", version.ref = "smithy-version" }
 smithy-cli = { module = "software.amazon.smithy:smithy-cli", version.ref = "smithy-version" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Consolidates smithy kotlin versions into one

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
