### PR TITLE
chore: configure CI triggers for merge queues

### DIFF
--- a/.github/workflows/api-compat-verification.yml
+++ b/.github/workflows/api-compat-verification.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
       - '*-main'
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
@@ -18,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check for API compatibility
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'acknowledge-api-break') }}
+        if: ${{ github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'acknowledge-api-break') }}
         run: |
           git fetch origin ${{ github.base_ref }} --depth 1 && \
           git diff remotes/origin/${{ github.base_ref }} --numstat "*.api" | awk '

--- a/.github/workflows/changelog-verification.yml
+++ b/.github/workflows/changelog-verification.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
       - '*-main'
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   changelog-verification:

--- a/.github/workflows/continuous-integration-reduced.yml
+++ b/.github/workflows/continuous-integration-reduced.yml
@@ -4,6 +4,8 @@ name: CI w/ reduced Smithy Kotlin
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -2,6 +2,8 @@ name: E2E tests
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/kat-transform.yml
+++ b/.github/workflows/kat-transform.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
       - '*-main'
+  merge_group:
+    types: [checks_requested]
 
 # Allow one instance of this workflow per pull request, and cancel older runs when new changes are pushed
 concurrency:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
       - '*-main'
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/minor-version-bump.yml
+++ b/.github/workflows/minor-version-bump.yml
@@ -1,6 +1,8 @@
 name: Minor version bump check
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   minor-version-bump-check:

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -7,13 +7,15 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
     branches: [ main ]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
 
 jobs:
   release-readiness:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ready-for-release') }}
+    if: ${{ github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'ready-for-release') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout SDK

--- a/.github/workflows/service-ci.yml
+++ b/.github/workflows/service-ci.yml
@@ -2,6 +2,8 @@ name: Service CI
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Issue \#

(none)

## Description of changes

This change prepares for enabling [merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) on our **main** branch. In particular, merge queues trigger the `merge_group` event and expect all required checks to pass. Without adding the relevant trigger to the workflows, the required checks would not run and the merge groups would be unable to be merged.

For most workflows, the change is simple: if there's already a `pull_request` trigger then we can just add a `merge_group` trigger alongside. Our label-checking workflows (e.g., **api-compat-verification**) won't work in a merge group because labels are gone by that point. Fortunately, the label checks don't need to be re-run in merge groups since they already passed in PR. So the strategy for label-checking is to skip it for `merge_group` events.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
