### PR TITLE
Retry standard strategy

### DIFF
--- a/.changes/63e5c52a-caf3-42a7-97d2-eabfaf8b1921.json
+++ b/.changes/63e5c52a-caf3-42a7-97d2-eabfaf8b1921.json
@@ -1,0 +1,5 @@
+{
+  "id": "63e5c52a-caf3-42a7-97d2-eabfaf8b1921",
+  "type": "feature",
+  "description": "Add new standard retry behavior behind `AWS_NEW_RETRIES_2026` feature flag with updated backoff defaults, DynamoDB-specific overrides, and service-scoped error classification"
+}

--- a/aws-runtime/aws-config/build.gradle.kts
+++ b/aws-runtime/aws-config/build.gradle.kts
@@ -8,6 +8,7 @@ import aws.sdk.kotlin.gradle.codegen.smithyKotlinProjectionSrcDir
 
 plugins {
     alias(libs.plugins.aws.kotlin.repo.tools.smithybuild)
+    alias(libs.plugins.kotlinx.serialization)
 }
 
 description = "Support for AWS configuration"
@@ -59,6 +60,7 @@ kotlin {
             dependencies {
                 implementation(libs.mockk)
                 implementation(libs.kotest.runner.junit5)
+                implementation(libs.kaml)
             }
         }
 

--- a/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactory.kt
+++ b/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactory.kt
@@ -60,6 +60,7 @@ public abstract class AbstractAwsSdkClientFactory<
      * The service name (sdkId) used for service-specific retry behavior (e.g., DynamoDB backoff tuning).
      */
     protected abstract val serviceName: String
+
     /**
      * Construct a [TClient] by resolving the configuration from the current environment.
      */

--- a/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactory.kt
+++ b/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactory.kt
@@ -55,6 +55,11 @@ public abstract class AbstractAwsSdkClientFactory<
           TConfig : AwsSdkClientConfig,
           TConfigBuilder : SdkClientConfig.Builder<TConfig>,
           TConfigBuilder : AwsSdkClientConfig.Builder {
+
+    /**
+     * The service name (sdkId) used for service-specific retry behavior (e.g., DynamoDB backoff tuning).
+     */
+    protected abstract val serviceName: String
     /**
      * Construct a [TClient] by resolving the configuration from the current environment.
      */
@@ -75,7 +80,7 @@ public abstract class AbstractAwsSdkClientFactory<
             // As a DslBuilderProperty, the value of retryStrategy cannot be checked for nullability because it may have
             // been set using a DSL. Thus, set the resolved strategy _first_ to ensure it's used as the fallback.
             if (config is RetryStrategyClientConfig.Builder) {
-                config.retryStrategy = resolveRetryStrategy(profile = profile)
+                config.retryStrategy = resolveRetryStrategy(serviceName = serviceName, profile = profile)
             }
 
             block?.let(config::apply)

--- a/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/AwsSdkSetting.kt
+++ b/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/AwsSdkSetting.kt
@@ -237,6 +237,12 @@ public object AwsSdkSetting {
      * Configures an ordered preference of auth schemes
      */
     public val AwsAuthSchemePreference: EnvironmentSetting<String> = strEnvSetting("aws.authSchemePreference", "AWS_AUTH_SCHEME_PREFERENCE")
+
+    /**
+     * Enables the standard retry strategy behavior. When set, takes precedence over the
+     * `SMITHY_NEW_RETRIES_2026` environment variable defined in smithy-kotlin.
+     */
+    public val AwsNewRetries: EnvironmentSetting<Boolean> = boolEnvSetting("aws.newRetries2026", "AWS_NEW_RETRIES_2026")
 }
 
 /**

--- a/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategy.kt
+++ b/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategy.kt
@@ -15,12 +15,33 @@ import aws.sdk.kotlin.runtime.config.profile.retryMode
 import aws.smithy.kotlin.runtime.client.config.RetryMode
 import aws.smithy.kotlin.runtime.config.resolve
 import aws.smithy.kotlin.runtime.retries.AdaptiveRetryStrategy
+import aws.smithy.kotlin.runtime.retries.CoreSettings
 import aws.smithy.kotlin.runtime.retries.RetryStrategy
 import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
-import aws.smithy.kotlin.runtime.retries.newRetriesEnabled
 import aws.smithy.kotlin.runtime.util.LazyAsyncValue
 import aws.smithy.kotlin.runtime.util.PlatformProvider
 import aws.smithy.kotlin.runtime.util.asyncLazy
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Services that use a shorter initial backoff delay (25ms instead of the standard 50ms).
+ */
+private val SHORT_BACKOFF_SERVICES = setOf("dynamodb", "dynamodb streams")
+
+/**
+ * The initial backoff delay for DynamoDB and DynamoDB Streams (SEP Retry Behavior 2.1: x = 0.025).
+ */
+private val DYNAMODB_INITIAL_DELAY = 25.milliseconds
+
+/**
+ * Services that use an increased default max attempts (4 instead of the standard 3).
+ */
+private val INCREASED_MAX_ATTEMPTS_SERVICES = SHORT_BACKOFF_SERVICES
+
+/**
+ * The default max attempts for DynamoDB and DynamoDB Streams.
+ */
+private const val DYNAMODB_DEFAULT_MAX_ATTEMPTS = 4
 
 /**
  * Attempt to resolve the retry strategy used to make requests by fetching the max attempts and retry mode.
@@ -33,9 +54,13 @@ public suspend fun resolveRetryStrategy(
     profile: LazyAsyncValue<AwsProfile> = asyncLazy { loadAwsSharedConfig(platformProvider).activeProfile },
     serviceName: String? = null,
 ): RetryStrategy {
-    val useNewRetries = AwsSdkSetting.AwsNewRetries.resolve(platformProvider) ?: newRetriesEnabled()
+    val useNewRetries = AwsSdkSetting.AwsNewRetries.resolve(platformProvider) ?: CoreSettings.NewRetriesEnabled
     val maxAttempts = AwsSdkSetting.AwsMaxAttempts.resolve(platformProvider)
         ?: profile.get().maxAttempts
+
+    maxAttempts?.let {
+        if (it < 1) throw ConfigurationException("max attempts was $it, but should be at least 1")
+    }
 
     val retryMode = AwsSdkSetting.AwsRetryMode.resolve(platformProvider)
         ?: profile.get().retryMode
@@ -47,13 +72,38 @@ public suspend fun resolveRetryStrategy(
     }
 
     return factory {
-        maxAttempts?.let {
-            if (it < 1) {
-                throw ConfigurationException("max attempts was $it, but should be at least 1")
-            }
-            this.maxAttempts = it
-        }
-        serviceName?.let { this.serviceName = it }
-        if (useNewRetries) enableStandardRetryDefaults()
+        configureRetryDefaults(serviceName, maxAttempts, useNewRetries)
     }
+}
+
+/**
+ * Configures the retry strategy builder with the resolved max attempts and, when new retries are enabled,
+ * AWS service-specific defaults as defined in the Retry Behavior 2.1 SEP.
+ *
+ * When [useNewRetries] is `true` and [serviceName] identifies DynamoDB or DynamoDB Streams:
+ * - Sets `initialDelay` to 25ms (instead of the standard 50ms)
+ * - Sets `maxAttempts` to 4 (instead of the standard 3), unless [configuredMaxAttempts] is provided
+ */
+@InternalSdkApi
+public fun StandardRetryStrategy.Config.Builder.configureRetryDefaults(
+    serviceName: String? = null,
+    configuredMaxAttempts: Int? = null,
+    useNewRetries: Boolean = false,
+) {
+    if (!useNewRetries) {
+        configuredMaxAttempts?.let { maxAttempts = it }
+        return
+    }
+
+    val normalizedName = serviceName?.lowercase()
+
+    if (normalizedName in SHORT_BACKOFF_SERVICES) {
+        delayProvider {
+            initialDelay = DYNAMODB_INITIAL_DELAY
+        }
+    }
+
+    maxAttempts = configuredMaxAttempts
+        ?: if (normalizedName in INCREASED_MAX_ATTEMPTS_SERVICES) DYNAMODB_DEFAULT_MAX_ATTEMPTS
+        else StandardRetryStrategy.Config.DEFAULT_MAX_ATTEMPTS
 }

--- a/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategy.kt
+++ b/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategy.kt
@@ -23,7 +23,7 @@ import aws.smithy.kotlin.runtime.util.PlatformProvider
 import aws.smithy.kotlin.runtime.util.asyncLazy
 import kotlin.time.Duration.Companion.milliseconds
 
-// Standard retry defaults (SEP Retry Behavior 2.1)
+// Standard retry defaults (New Retry Behavior)
 private val STANDARD_INITIAL_DELAY = 50.milliseconds
 private const val STANDARD_SCALE_FACTOR = 2.0
 private const val STANDARD_RETRY_COST = 14
@@ -70,10 +70,6 @@ public suspend fun resolveRetryStrategy(
 /**
  * Configures the retry strategy builder with the resolved max attempts and, when new retries are enabled,
  * all standard defaults as defined in the New Retry Behavior.
- *
- * When [useNewRetries] is `true`:
- * - Sets scaleFactor=2.0, retryCost=14, timeoutRetryCost=5, initialDelay=50ms
- * - For DynamoDB / DynamoDB Streams: initialDelay=25ms, maxAttempts=4
  */
 @InternalSdkApi
 public fun StandardRetryStrategy.Config.Builder.configureRetryDefaults(
@@ -99,6 +95,9 @@ public fun StandardRetryStrategy.Config.Builder.configureRetryDefaults(
     }
 
     maxAttempts = configuredMaxAttempts
-        ?: if (isDynamoDb) DYNAMODB_DEFAULT_MAX_ATTEMPTS
-        else StandardRetryStrategy.Config.DEFAULT_MAX_ATTEMPTS
+        ?: if (isDynamoDb) {
+            DYNAMODB_DEFAULT_MAX_ATTEMPTS
+        } else {
+            StandardRetryStrategy.Config.DEFAULT_MAX_ATTEMPTS
+        }
 }

--- a/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategy.kt
+++ b/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategy.kt
@@ -23,30 +23,21 @@ import aws.smithy.kotlin.runtime.util.PlatformProvider
 import aws.smithy.kotlin.runtime.util.asyncLazy
 import kotlin.time.Duration.Companion.milliseconds
 
-/**
- * Services that use a shorter initial backoff delay (25ms instead of the standard 50ms).
- */
-private val SHORT_BACKOFF_SERVICES = setOf("dynamodb", "dynamodb streams")
+// Standard retry defaults (SEP Retry Behavior 2.1)
+private val STANDARD_INITIAL_DELAY = 50.milliseconds
+private const val STANDARD_SCALE_FACTOR = 2.0
+private const val STANDARD_RETRY_COST = 14
+private const val STANDARD_THROTTLING_RETRY_COST = 5
 
-/**
- * The initial backoff delay for DynamoDB and DynamoDB Streams (SEP Retry Behavior 2.1: x = 0.025).
- */
+// DynamoDB / DynamoDB Streams overrides
+private val DYNAMODB_SERVICES = setOf("dynamodb", "dynamodb streams")
 private val DYNAMODB_INITIAL_DELAY = 25.milliseconds
-
-/**
- * Services that use an increased default max attempts (4 instead of the standard 3).
- */
-private val INCREASED_MAX_ATTEMPTS_SERVICES = SHORT_BACKOFF_SERVICES
-
-/**
- * The default max attempts for DynamoDB and DynamoDB Streams.
- */
 private const val DYNAMODB_DEFAULT_MAX_ATTEMPTS = 4
 
 /**
  * Attempt to resolve the retry strategy used to make requests by fetching the max attempts and retry mode.
- * If `AWS_NEW_RETRIES_2026` (or `aws.newRetries2026` system property) is set to `true`, the standard retry
- * strategy behavior is enabled. Falls back to smithy-kotlin's `SMITHY_NEW_RETRIES_2026` / `smithy.newRetries2026`.
+ * If `AWS_NEW_RETRIES_2026` is set to `true`, the standard retry strategy behavior is enabled.
+ * Falls back to smithy-kotlin's `SMITHY_NEW_RETRIES_2026`.
  */
 @InternalSdkApi
 public suspend fun resolveRetryStrategy(
@@ -78,11 +69,11 @@ public suspend fun resolveRetryStrategy(
 
 /**
  * Configures the retry strategy builder with the resolved max attempts and, when new retries are enabled,
- * AWS service-specific defaults as defined in the Retry Behavior 2.1 SEP.
+ * all standard defaults as defined in the New Retry Behavior.
  *
- * When [useNewRetries] is `true` and [serviceName] identifies DynamoDB or DynamoDB Streams:
- * - Sets `initialDelay` to 25ms (instead of the standard 50ms)
- * - Sets `maxAttempts` to 4 (instead of the standard 3), unless [configuredMaxAttempts] is provided
+ * When [useNewRetries] is `true`:
+ * - Sets scaleFactor=2.0, retryCost=14, timeoutRetryCost=5, initialDelay=50ms
+ * - For DynamoDB / DynamoDB Streams: initialDelay=25ms, maxAttempts=4
  */
 @InternalSdkApi
 public fun StandardRetryStrategy.Config.Builder.configureRetryDefaults(
@@ -95,15 +86,19 @@ public fun StandardRetryStrategy.Config.Builder.configureRetryDefaults(
         return
     }
 
-    val normalizedName = serviceName?.lowercase()
+    val isDynamoDb = serviceName?.lowercase() in DYNAMODB_SERVICES
 
-    if (normalizedName in SHORT_BACKOFF_SERVICES) {
-        delayProvider {
-            initialDelay = DYNAMODB_INITIAL_DELAY
-        }
+    delayProvider {
+        initialDelay = if (isDynamoDb) DYNAMODB_INITIAL_DELAY else STANDARD_INITIAL_DELAY
+        scaleFactor = STANDARD_SCALE_FACTOR
+    }
+
+    tokenBucket {
+        retryCost = STANDARD_RETRY_COST
+        timeoutRetryCost = STANDARD_THROTTLING_RETRY_COST
     }
 
     maxAttempts = configuredMaxAttempts
-        ?: if (normalizedName in INCREASED_MAX_ATTEMPTS_SERVICES) DYNAMODB_DEFAULT_MAX_ATTEMPTS
+        ?: if (isDynamoDb) DYNAMODB_DEFAULT_MAX_ATTEMPTS
         else StandardRetryStrategy.Config.DEFAULT_MAX_ATTEMPTS
 }

--- a/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategy.kt
+++ b/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategy.kt
@@ -17,19 +17,25 @@ import aws.smithy.kotlin.runtime.config.resolve
 import aws.smithy.kotlin.runtime.retries.AdaptiveRetryStrategy
 import aws.smithy.kotlin.runtime.retries.RetryStrategy
 import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
+import aws.smithy.kotlin.runtime.retries.delay.StandardExponentialBackoffWithJitter
+import aws.smithy.kotlin.runtime.retries.delay.StandardRetryTokenBucket
+import aws.smithy.kotlin.runtime.retries.newRetriesEnabled
 import aws.smithy.kotlin.runtime.util.LazyAsyncValue
 import aws.smithy.kotlin.runtime.util.PlatformProvider
 import aws.smithy.kotlin.runtime.util.asyncLazy
 
 /**
- * Attempt to resolve the retry strategy used to make requests by fetching the max attempts and retry mode. Currently,
- * we only support the legacy and standard retry modes.
+ * Attempt to resolve the retry strategy used to make requests by fetching the max attempts and retry mode.
+ * If `AWS_NEW_RETRIES_2026` (or `aws.newRetries2026` system property) is set to `true`, the standard retry
+ * strategy behavior is enabled. Falls back to smithy-kotlin's `SMITHY_NEW_RETRIES_2026` / `smithy.newRetries2026`.
  */
 @InternalSdkApi
 public suspend fun resolveRetryStrategy(
     platformProvider: PlatformProvider = PlatformProvider.System,
     profile: LazyAsyncValue<AwsProfile> = asyncLazy { loadAwsSharedConfig(platformProvider).activeProfile },
+    serviceName: String? = null,
 ): RetryStrategy {
+    val useNewRetries = AwsSdkSetting.AwsNewRetries.resolve(platformProvider) ?: newRetriesEnabled()
     val maxAttempts = AwsSdkSetting.AwsMaxAttempts.resolve(platformProvider)
         ?: profile.get().maxAttempts
 
@@ -48,6 +54,17 @@ public suspend fun resolveRetryStrategy(
                 throw ConfigurationException("max attempts was $it, but should be at least 1")
             }
             this.maxAttempts = it
+        }
+        serviceName?.let { this.serviceName = it }
+
+        // Configure the standard retry strategy behavior when enabled via AWS or smithy-kotlin flag
+        if (useNewRetries) {
+            delayProvider(StandardExponentialBackoffWithJitter) {}
+            tokenBucket(StandardRetryTokenBucket) {
+                retryCost = 14
+                timeoutRetryCost = 5
+                initialTrySuccessIncrement = 1
+            }
         }
     }
 }

--- a/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategy.kt
+++ b/aws-runtime/aws-config/common/src/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategy.kt
@@ -17,8 +17,6 @@ import aws.smithy.kotlin.runtime.config.resolve
 import aws.smithy.kotlin.runtime.retries.AdaptiveRetryStrategy
 import aws.smithy.kotlin.runtime.retries.RetryStrategy
 import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
-import aws.smithy.kotlin.runtime.retries.delay.StandardExponentialBackoffWithJitter
-import aws.smithy.kotlin.runtime.retries.delay.StandardRetryTokenBucket
 import aws.smithy.kotlin.runtime.retries.newRetriesEnabled
 import aws.smithy.kotlin.runtime.util.LazyAsyncValue
 import aws.smithy.kotlin.runtime.util.PlatformProvider
@@ -56,15 +54,6 @@ public suspend fun resolveRetryStrategy(
             this.maxAttempts = it
         }
         serviceName?.let { this.serviceName = it }
-
-        // Configure the standard retry strategy behavior when enabled via AWS or smithy-kotlin flag
-        if (useNewRetries) {
-            delayProvider(StandardExponentialBackoffWithJitter) {}
-            tokenBucket(StandardRetryTokenBucket) {
-                retryCost = 14
-                timeoutRetryCost = 5
-                initialTrySuccessIncrement = 1
-            }
-        }
+        if (useNewRetries) enableStandardRetryDefaults()
     }
 }

--- a/aws-runtime/aws-config/common/test/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategyTest.kt
+++ b/aws-runtime/aws-config/common/test/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategyTest.kt
@@ -10,6 +10,8 @@ import aws.sdk.kotlin.runtime.config.AwsSdkSetting
 import aws.smithy.kotlin.runtime.ClientException
 import aws.smithy.kotlin.runtime.retries.AdaptiveRetryStrategy
 import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
+import aws.smithy.kotlin.runtime.retries.delay.ExponentialBackoffWithJitter
+import aws.smithy.kotlin.runtime.retries.delay.StandardExponentialBackoffWithJitter
 import aws.smithy.kotlin.runtime.util.TestPlatformProvider
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -242,5 +244,39 @@ class ResolveRetryStrategyTest {
 
         val strategy = assertIs<StandardRetryStrategy>(resolveRetryStrategy(platform))
         assertEquals(expectedMaxAttempts, strategy.config.maxAttempts)
+    }
+
+    @Test
+    fun itUsesLegacyDefaultsWhenNoFlagsSet() = runTest {
+        val platform = TestPlatformProvider()
+        val strategy = assertIs<StandardRetryStrategy>(resolveRetryStrategy(platform))
+        assertIs<ExponentialBackoffWithJitter>(strategy.config.delayProvider)
+    }
+
+    @Test
+    fun itUsesNewDefaultsWhenAwsFlagSet() = runTest {
+        val platform = TestPlatformProvider(
+            env = mapOf(AwsSdkSetting.AwsNewRetries.envVar to "true"),
+        )
+        val strategy = assertIs<StandardRetryStrategy>(resolveRetryStrategy(platform))
+        assertIs<StandardExponentialBackoffWithJitter>(strategy.config.delayProvider)
+    }
+
+    @Test
+    fun itUsesLegacyDefaultsWhenAwsFlagFalse() = runTest {
+        val platform = TestPlatformProvider(
+            env = mapOf(AwsSdkSetting.AwsNewRetries.envVar to "false"),
+        )
+        val strategy = assertIs<StandardRetryStrategy>(resolveRetryStrategy(platform))
+        assertIs<ExponentialBackoffWithJitter>(strategy.config.delayProvider)
+    }
+
+    @Test
+    fun itPassesServiceNameToStrategy() = runTest {
+        val platform = TestPlatformProvider(
+            env = mapOf(AwsSdkSetting.AwsNewRetries.envVar to "true"),
+        )
+        val strategy = assertIs<StandardRetryStrategy>(resolveRetryStrategy(platform, serviceName = "DynamoDB"))
+        assertEquals("DynamoDB", strategy.config.serviceName)
     }
 }

--- a/aws-runtime/aws-config/common/test/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategyTest.kt
+++ b/aws-runtime/aws-config/common/test/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategyTest.kt
@@ -11,13 +11,13 @@ import aws.smithy.kotlin.runtime.ClientException
 import aws.smithy.kotlin.runtime.retries.AdaptiveRetryStrategy
 import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
 import aws.smithy.kotlin.runtime.retries.delay.ExponentialBackoffWithJitter
-import aws.smithy.kotlin.runtime.retries.delay.StandardExponentialBackoffWithJitter
 import aws.smithy.kotlin.runtime.util.TestPlatformProvider
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.time.Duration.Companion.milliseconds
 
 class ResolveRetryStrategyTest {
     @Test
@@ -259,7 +259,7 @@ class ResolveRetryStrategyTest {
             env = mapOf(AwsSdkSetting.AwsNewRetries.envVar to "true"),
         )
         val strategy = assertIs<StandardRetryStrategy>(resolveRetryStrategy(platform))
-        assertIs<StandardExponentialBackoffWithJitter>(strategy.config.delayProvider)
+        assertIs<ExponentialBackoffWithJitter>(strategy.config.delayProvider)
     }
 
     @Test
@@ -272,11 +272,22 @@ class ResolveRetryStrategyTest {
     }
 
     @Test
-    fun itPassesServiceNameToStrategy() = runTest {
+    fun itUsesDynamoDbDefaultsWhenNewRetriesEnabled() = runTest {
         val platform = TestPlatformProvider(
             env = mapOf(AwsSdkSetting.AwsNewRetries.envVar to "true"),
         )
         val strategy = assertIs<StandardRetryStrategy>(resolveRetryStrategy(platform, serviceName = "DynamoDB"))
-        assertEquals("DynamoDB", strategy.config.serviceName)
+        assertEquals(4, strategy.config.maxAttempts)
+        val delayer = assertIs<ExponentialBackoffWithJitter>(strategy.config.delayProvider)
+        assertEquals(25.milliseconds, delayer.config.initialDelay)
+    }
+
+    @Test
+    fun itUsesStandardDefaultsForNonDynamoDbWhenNewRetriesEnabled() = runTest {
+        val platform = TestPlatformProvider(
+            env = mapOf(AwsSdkSetting.AwsNewRetries.envVar to "true"),
+        )
+        val strategy = assertIs<StandardRetryStrategy>(resolveRetryStrategy(platform, serviceName = "S3"))
+        assertEquals(3, strategy.config.maxAttempts)
     }
 }

--- a/aws-runtime/aws-config/common/test/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategyTest.kt
+++ b/aws-runtime/aws-config/common/test/aws/sdk/kotlin/runtime/config/retries/ResolveRetryStrategyTest.kt
@@ -247,31 +247,6 @@ class ResolveRetryStrategyTest {
     }
 
     @Test
-    fun itUsesLegacyDefaultsWhenNoFlagsSet() = runTest {
-        val platform = TestPlatformProvider()
-        val strategy = assertIs<StandardRetryStrategy>(resolveRetryStrategy(platform))
-        assertIs<ExponentialBackoffWithJitter>(strategy.config.delayProvider)
-    }
-
-    @Test
-    fun itUsesNewDefaultsWhenAwsFlagSet() = runTest {
-        val platform = TestPlatformProvider(
-            env = mapOf(AwsSdkSetting.AwsNewRetries.envVar to "true"),
-        )
-        val strategy = assertIs<StandardRetryStrategy>(resolveRetryStrategy(platform))
-        assertIs<ExponentialBackoffWithJitter>(strategy.config.delayProvider)
-    }
-
-    @Test
-    fun itUsesLegacyDefaultsWhenAwsFlagFalse() = runTest {
-        val platform = TestPlatformProvider(
-            env = mapOf(AwsSdkSetting.AwsNewRetries.envVar to "false"),
-        )
-        val strategy = assertIs<StandardRetryStrategy>(resolveRetryStrategy(platform))
-        assertIs<ExponentialBackoffWithJitter>(strategy.config.delayProvider)
-    }
-
-    @Test
     fun itUsesDynamoDbDefaultsWhenNewRetriesEnabled() = runTest {
         val platform = TestPlatformProvider(
             env = mapOf(AwsSdkSetting.AwsNewRetries.envVar to "true"),
@@ -280,6 +255,17 @@ class ResolveRetryStrategyTest {
         assertEquals(4, strategy.config.maxAttempts)
         val delayer = assertIs<ExponentialBackoffWithJitter>(strategy.config.delayProvider)
         assertEquals(25.milliseconds, delayer.config.initialDelay)
+    }
+
+    @Test
+    fun itUsesDynamoDbDefaultsWhenNewRetriesDisabled() = runTest {
+        val platform = TestPlatformProvider(
+            env = mapOf(AwsSdkSetting.AwsNewRetries.envVar to "false"),
+        )
+        val strategy = assertIs<StandardRetryStrategy>(resolveRetryStrategy(platform, serviceName = "DynamoDB"))
+        assertEquals(3, strategy.config.maxAttempts)
+        val delayer = assertIs<ExponentialBackoffWithJitter>(strategy.config.delayProvider)
+        assertEquals(10.milliseconds, delayer.config.initialDelay)
     }
 
     @Test

--- a/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactoryTest.kt
+++ b/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/config/AbstractAwsSdkClientFactoryTest.kt
@@ -111,6 +111,7 @@ private interface TestClient : SdkClient {
 
     // refactored: mostly in an abstract base now
     companion object : AbstractAwsSdkClientFactory<Config, Config.Builder, TestClient, Builder>() {
+        override val serviceName: String = "Test"
         override fun builder(): Builder = Builder()
     }
 

--- a/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/config/retries/AwsRetryIntegrationTest.kt
+++ b/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/config/retries/AwsRetryIntegrationTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.sdk.kotlin.runtime.config.retries
+
+import aws.smithy.kotlin.runtime.retries.RetryContext
+import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
+import aws.smithy.kotlin.runtime.retries.getOrThrow
+import aws.smithy.kotlin.runtime.retries.policy.RetryDirective
+import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
+import aws.smithy.kotlin.runtime.retries.policy.RetryPolicy
+import com.charleskorn.kaml.Yaml
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlin.test.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AwsRetryIntegrationTest {
+
+    @Test
+    fun testAwsServiceSpecificRetryCases() = runTest {
+        val testCases = awsRetryTestCases.mapValues {
+            Yaml.default.decodeFromString(AwsRetryTestCase.serializer(), it.value)
+        }
+
+        testCases.forEach { (name, tc) ->
+            val strategy = StandardRetryStrategy {
+                configureRetryDefaults(
+                    serviceName = tc.given.service,
+                    configuredMaxAttempts = tc.given.maxAttempts,
+                    useNewRetries = true,
+                )
+                delayProvider {
+                    if (tc.given.exponentialBase == 1.0) jitter = 0.0
+                }
+            }
+
+            val policy = object : RetryPolicy<Unit> {
+                override fun evaluate(result: Result<Unit>): RetryDirective = when {
+                    result.isSuccess -> RetryDirective.TerminateAndSucceed
+                    else -> RetryDirective.RetryError(RetryErrorType.ServerSide)
+                }
+            }
+
+            var attempt = 0
+            val startTime = currentTime
+
+            val result = runCatching {
+                withContext(RetryContext()) {
+                    strategy.retry(policy) {
+                        val code = tc.responses[attempt++].response.statusCode
+                        if (code != 200) throw TestServerException(code)
+                    }
+                }
+            }
+
+            val totalDelayMs = currentTime - startTime
+            val expectedDelayMs = tc.responses.mapNotNull { it.expected.delay }.sumOf { (it * 1000).toLong() }
+            val finalOutcome = tc.responses.last().expected.outcome
+
+            when (finalOutcome) {
+                AwsRetryOutcome.Success ->
+                    assertTrue(result.isSuccess, "Expected success for '$name' but got ${result.exceptionOrNull()}")
+                AwsRetryOutcome.MaxAttemptsExceeded ->
+                    assertIs<TestServerException>(result.exceptionOrNull(), "Expected exception for '$name'")
+                AwsRetryOutcome.RetryRequest ->
+                    fail("Final outcome should not be retry_request for '$name'")
+            }
+
+            assertEquals(expectedDelayMs, totalDelayMs, "Delay mismatch for '$name'")
+        }
+    }
+}
+
+private class TestServerException(val code: Int) : Exception("HTTP $code")

--- a/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/config/retries/AwsRetryIntegrationTestResources.kt
+++ b/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/config/retries/AwsRetryIntegrationTestResources.kt
@@ -70,7 +70,12 @@ data class AwsRetryExpectation(
 
 @Serializable
 enum class AwsRetryOutcome {
-    @SerialName("success") Success,
-    @SerialName("retry_request") RetryRequest,
-    @SerialName("max_attempts_exceeded") MaxAttemptsExceeded,
+    @SerialName("success")
+    Success,
+
+    @SerialName("retry_request")
+    RetryRequest,
+
+    @SerialName("max_attempts_exceeded")
+    MaxAttemptsExceeded,
 }

--- a/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/config/retries/AwsRetryIntegrationTestResources.kt
+++ b/aws-runtime/aws-config/jvm/test/aws/sdk/kotlin/runtime/config/retries/AwsRetryIntegrationTestResources.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package aws.sdk.kotlin.runtime.config.retries
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * SEP test cases that are service-specific and owned by aws-sdk-kotlin.
+ * Matches the YAML from the "Standard Mode Testcases" section of the Retry Behavior 2.1 SEP.
+ */
+val awsRetryTestCases = mapOf(
+    "DynamoDB Base Backoff (25ms) and Increased Retries" to // language=YAML
+        """
+            given:
+              service: dynamodb
+              exponential_base: 1
+            responses:
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 486
+                  delay: 0.025
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 472
+                  delay: 0.05
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: retry_request
+                  retry_quota: 458
+                  delay: 0.1
+              - response:
+                  status_code: 500
+                expected:
+                  outcome: max_attempts_exceeded
+                  retry_quota: 458
+        """.trimIndent(),
+)
+
+@Serializable
+data class AwsRetryTestCase(val given: AwsRetryGiven, val responses: List<AwsRetryResponseAndExpectation>)
+
+@Serializable
+data class AwsRetryGiven(
+    val service: String,
+    @SerialName("max_attempts") val maxAttempts: Int? = null,
+    @SerialName("exponential_base") val exponentialBase: Double? = null,
+)
+
+@Serializable
+data class AwsRetryResponseAndExpectation(val response: AwsRetryResponse, val expected: AwsRetryExpectation)
+
+@Serializable
+data class AwsRetryResponse(@SerialName("status_code") val statusCode: Int)
+
+@Serializable
+data class AwsRetryExpectation(
+    val outcome: AwsRetryOutcome,
+    @SerialName("retry_quota") val retryQuota: Int? = null,
+    val delay: Double? = null,
+)
+
+@Serializable
+enum class AwsRetryOutcome {
+    @SerialName("success") Success,
+    @SerialName("retry_request") RetryRequest,
+    @SerialName("max_attempts_exceeded") MaxAttemptsExceeded,
+}

--- a/aws-runtime/aws-http/common/src/aws/sdk/kotlin/runtime/http/retries/AwsRetryPolicy.kt
+++ b/aws-runtime/aws-http/common/src/aws/sdk/kotlin/runtime/http/retries/AwsRetryPolicy.kt
@@ -20,7 +20,7 @@ import aws.smithy.kotlin.runtime.retries.policy.StandardRetryPolicy
  * * Any [ServiceException] with an `sdkErrorMetadata.errorCode` of:
  *   * `BandwidthLimitExceeded`
  *   * `EC2ThrottledException`
- *   * `IDPCommunicationError`
+ *   * `IDPCommunicationError` (STS only)
  *   * `LimitExceededException`
  *   * `PriorRequestNotComplete`
  *   * `ProvisionedThroughputExceededException`
@@ -43,8 +43,11 @@ import aws.smithy.kotlin.runtime.retries.policy.StandardRetryPolicy
  *
  * If none of those conditions match, this policy delegates to [StandardRetryPolicy]. See that class's documentation for
  * more information about how it evaluates exceptions.
+ *
+ * @param serviceName The optional sdkId of the service (e.g. `"STS"`). When provided, service-scoped error codes
+ * such as `IDPCommunicationError` are only retried for the matching service.
  */
-public open class AwsRetryPolicy : StandardRetryPolicy() {
+public open class AwsRetryPolicy(private val serviceName: String? = null) : StandardRetryPolicy() {
     public companion object {
         /**
          * The default [aws.smithy.kotlin.runtime.retries.policy.RetryPolicy] used by AWS service clients
@@ -54,7 +57,6 @@ public open class AwsRetryPolicy : StandardRetryPolicy() {
         internal val knownErrorTypes = mapOf(
             "BandwidthLimitExceeded" to Throttling,
             "EC2ThrottledException" to Throttling,
-            "IDPCommunicationError" to Transient,
             "LimitExceededException" to Throttling,
             "PriorRequestNotComplete" to Throttling,
             "ProvisionedThroughputExceededException" to Throttling,
@@ -71,6 +73,14 @@ public open class AwsRetryPolicy : StandardRetryPolicy() {
             "TransactionInProgressException" to Throttling,
         )
 
+        /**
+         * Error codes that are only retryable for specific services.
+         * Maps error code to (RetryErrorType, set of matching service names lowercased).
+         */
+        internal val serviceSpecificErrorTypes = mapOf(
+            "IDPCommunicationError" to (Transient to setOf("sts")),
+        )
+
         internal val knownStatusCodes = mapOf(
             500 to Transient,
             502 to Transient,
@@ -85,8 +95,12 @@ public open class AwsRetryPolicy : StandardRetryPolicy() {
     }
 
     private fun evaluateServiceException(ex: ServiceException): RetryDirective? = with(ex.sdkErrorMetadata) {
-        (knownErrorTypes[errorCode] ?: knownStatusCodes[statusCode])
-            ?.let { RetryDirective.RetryError(it) }
+        val errorType = knownErrorTypes[errorCode]
+            ?: serviceSpecificErrorTypes[errorCode]?.let { (type, services) ->
+                type.takeIf { serviceName?.lowercase() in services }
+            }
+            ?: knownStatusCodes[statusCode]
+        errorType?.let { RetryDirective.RetryError(it) }
     }
 
     private val ServiceErrorMetadata.statusCode: Int?

--- a/aws-runtime/aws-http/common/test/aws/sdk/kotlin/runtime/http/retries/AwsRetryPolicyTest.kt
+++ b/aws-runtime/aws-http/common/test/aws/sdk/kotlin/runtime/http/retries/AwsRetryPolicyTest.kt
@@ -11,6 +11,7 @@ import aws.smithy.kotlin.runtime.http.HttpBody
 import aws.smithy.kotlin.runtime.http.HttpStatusCode
 import aws.smithy.kotlin.runtime.http.response.HttpResponse
 import aws.smithy.kotlin.runtime.retries.policy.RetryDirective
+import aws.smithy.kotlin.runtime.retries.policy.RetryErrorType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -35,5 +36,29 @@ class AwsRetryPolicyTest {
             val result = AwsRetryPolicy.Default.evaluate(Result.failure(ex))
             assertEquals(RetryDirective.RetryError(errorType), result)
         }
+    }
+
+    @Test
+    fun testIDPCommunicationErrorRetriedForSts() {
+        val policy = AwsRetryPolicy("STS")
+        val ex = ServiceException()
+        ex.sdkErrorMetadata.attributes[ServiceErrorMetadata.ErrorCode] = "IDPCommunicationError"
+        assertEquals(RetryDirective.RetryError(RetryErrorType.Transient), policy.evaluate(Result.failure(ex)))
+    }
+
+    @Test
+    fun testIDPCommunicationErrorNotRetriedForOtherServices() {
+        val policy = AwsRetryPolicy("IAM")
+        val ex = ServiceException()
+        ex.sdkErrorMetadata.attributes[ServiceErrorMetadata.ErrorCode] = "IDPCommunicationError"
+        assertEquals(RetryDirective.TerminateAndFail, policy.evaluate(Result.failure(ex)))
+    }
+
+    @Test
+    fun testIDPCommunicationErrorNotRetriedWithoutServiceName() {
+        val policy = AwsRetryPolicy()
+        val ex = ServiceException()
+        ex.sdkErrorMetadata.attributes[ServiceErrorMetadata.ErrorCode] = "IDPCommunicationError"
+        assertEquals(RetryDirective.TerminateAndFail, policy.evaluate(Result.failure(ex)))
     }
 }

--- a/codegen/aws-sdk-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/AwsServiceConfigIntegration.kt
+++ b/codegen/aws-sdk-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/AwsServiceConfigIntegration.kt
@@ -134,7 +134,7 @@ class AwsServiceConfigIntegration : KotlinIntegration {
             .RetryPolicy
             .toBuilder()
             .apply {
-                propertyType = ConfigPropertyType.RequiredWithDefault("AwsRetryPolicy.Default")
+                propertyType = ConfigPropertyType.RequiredWithDefault("AwsRetryPolicy(ServiceId)")
                 additionalImports = listOf(AwsRuntimeTypes.Http.Retries.AwsRetryPolicy)
             }
             .build()

--- a/codegen/aws-sdk-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/ServiceClientCompanionObjectWriter.kt
+++ b/codegen/aws-sdk-codegen/src/main/kotlin/aws/sdk/kotlin/codegen/ServiceClientCompanionObjectWriter.kt
@@ -22,6 +22,9 @@ class ServiceClientCompanionObjectWriter : AppendingSectionWriter {
     object FinalizeEnvironmentalConfig : SectionId
 
     override fun append(writer: KotlinWriter) {
+        writer.write("")
+        writer.write("override val serviceName: String = ServiceId")
+
         val funName = "finalizeEnvironmentalConfig"
         writer.write("")
         writer.withBlock(

--- a/codegen/aws-sdk-codegen/src/test/kotlin/aws/sdk/kotlin/codegen/ServiceClientCompanionObjectWriterTest.kt
+++ b/codegen/aws-sdk-codegen/src/test/kotlin/aws/sdk/kotlin/codegen/ServiceClientCompanionObjectWriterTest.kt
@@ -23,6 +23,8 @@ class ServiceClientCompanionObjectWriterTest {
         ServiceClientCompanionObjectWriter().write(writer, null)
 
         val expected = """
+            override val serviceName: String = ServiceId
+
             override suspend fun finalizeEnvironmentalConfig(builder: Builder, sharedConfig: LazyAsyncValue<AwsSharedConfig>, activeProfile: LazyAsyncValue<AwsProfile>) {
                 super.finalizeEnvironmentalConfig(builder, sharedConfig, activeProfile)
                 builder.config.endpointUrl = builder.config.endpointUrl ?: resolveEndpointUrl(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ ddb-local-version = "2.6.1"
 kotest-version = "5.9.1"
 kotlinx-benchmark-version = "0.4.16"
 kotlinx-serialization-version = "1.11.0"
+kaml-version = "0.55.0"
 mockk-version = "1.14.9"
 slf4j-version = "2.0.17"
 jsoup-version = "1.22.2"
@@ -112,6 +113,7 @@ kotest-assertions-core-jvm = { module = "io.kotest:kotest-assertions-core-jvm", 
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest-version" }
 kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark-version" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-version" }
+kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml-version" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk-version" }
 
 ddb-local = { module = "com.amazonaws:DynamoDBLocal", version.ref = "ddb-local-version" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an open issue, please link to the issue here -->

## Description of changes
Implement New Retry Behavior (Retry 2.1 SEP) for AWS SDK Kotlin                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                          
  Adds support for the new standard retry behavior behind the AWS_NEW_RETRIES_2026 feature flag:                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                          
  - New retry defaults: 50ms initial backoff (scaled ×2), retry cost of 14, throttling cost of 5                                                                                                                                                                                                                                                                          
  - DynamoDB-specific overrides: 25ms initial backoff, 4 max attempts (vs default 3)                                                                                                                                                                                                                                                                                      
  - Service-scoped error codes: IDPCommunicationError is now only retried for STS (previously retried for all services)                                                                                                                                                                                                                                                   
  - Service name plumbing: Added abstract serviceName property to `AbstractAwsSdkClientFactory`, codegen emits `ServiceId` override, and `AwsRetryPolicy` accepts an optional service name for scoped error handling                                                                                                                                                            
  - Tests: Unit tests for DynamoDB/non-DynamoDB defaults, service-scoped error codes, and YAML-driven integration tests matching the SEP test cases                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                          
  When `AWS_NEW_RETRIES_2026` is not set, behavior is unchanged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
